### PR TITLE
feat: 공통 응답 포맷 및 예외 처리 구조 설정 (#7)

### DIFF
--- a/src/main/java/com/reservation/global/common/dto/ErrorResponse.java
+++ b/src/main/java/com/reservation/global/common/dto/ErrorResponse.java
@@ -1,0 +1,44 @@
+package com.reservation.global.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.reservation.global.exception.code.ErrorCode;
+import lombok.Builder;
+import lombok.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Builder
+public record ErrorResponse<T>(
+        @NonNull String code,
+        @NonNull String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL) T detail
+) {
+
+    public static ResponseEntity<ErrorResponse<Void>> handle(ErrorCode errorCode) {
+        return ResponseEntity.status(HttpStatus.valueOf(errorCode.getValue())).body(from(errorCode));
+    }
+
+    public static ResponseEntity<ErrorResponse<Map<String, String>>> handle(ErrorCode errorCode,
+                                                                            List<FieldError> fieldErrors) {
+        return ResponseEntity.status(HttpStatus.valueOf(errorCode.getValue())).body(of(errorCode, fieldErrors));
+    }
+
+    private static <T> ErrorResponse<T> from(ErrorCode errorCode) {
+        return new ErrorResponse<>(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    private static ErrorResponse<Map<String, String>> of(ErrorCode errorCode, List<FieldError> fieldErrors) {
+        return new ErrorResponse<>(errorCode.getCode(), errorCode.getMessage(), convertErrors(fieldErrors));
+    }
+
+    private static Map<String, String> convertErrors(List<FieldError> fieldErrors) {
+        return fieldErrors.stream()
+                .filter(fieldError -> fieldError.getDefaultMessage() != null)
+                .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage));
+    }
+}

--- a/src/main/java/com/reservation/global/exception/GeneralException.java
+++ b/src/main/java/com/reservation/global/exception/GeneralException.java
@@ -1,0 +1,17 @@
+package com.reservation.global.exception;
+
+import com.reservation.global.exception.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    @Override
+    public String getMessage() {
+        return "[%s] %s".formatted(errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/reservation/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/reservation/global/exception/code/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.reservation.global.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INTERNAL_SERVER_ERROR(500, "COMMON000", "서버 에러, 관리자에게 문의 바랍니다."),
+    BAD_REQUEST(400, "COMMON001", "잘못된 요청입니다."),
+    METHOD_NOT_ALLOWED(405, "COMMON002", "지원하지 않는 Http Method 입니다."),
+    VALIDATION_FAILED(400, "COMMON003", "입력값에 대한 검증에 실패했습니다."),
+    ;
+
+    private final int value;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/reservation/global/exception/handler/GeneralExceptionHandler.java
+++ b/src/main/java/com/reservation/global/exception/handler/GeneralExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.reservation.global.exception.handler;
+
+import com.reservation.global.common.dto.ErrorResponse;
+import com.reservation.global.exception.GeneralException;
+import com.reservation.global.exception.code.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GeneralExceptionHandler {
+
+    @ExceptionHandler(GeneralException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleGeneralException(GeneralException ex) {
+        log.warn("{} : {}", ex.getClass().getSimpleName(), ex.getMessage());
+        return ErrorResponse.handle(ex.getErrorCode());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse<Map<String, String>>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        log.warn("{} : {}", ex.getClass().getSimpleName(), ex.getMessage());
+        return ErrorResponse.handle(ErrorCode.VALIDATION_FAILED, ex.getFieldErrors());
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleHandlerMethodValidationException(HandlerMethodValidationException ex) {
+        log.warn("{} : {}", ex.getClass().getSimpleName(), ex.getMessage());
+        return ErrorResponse.handle(ErrorCode.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex) {
+        log.warn("{} : {}", ex.getClass().getSimpleName(), ex.getMessage());
+        return ErrorResponse.handle(ErrorCode.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        log.warn("{} : {}", ex.getClass().getSimpleName(), ex.getMessage());
+        return ErrorResponse.handle(ErrorCode.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleException(Exception ex) {
+        log.error("{} : {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
+        return ErrorResponse.handle(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary
- `ErrorCode` enum: HTTP 상태코드, 에러코드, 메시지 매핑
- `GeneralException`: ErrorCode 기반 커스텀 예외
- `ErrorResponse` record: code, message, detail 포함 에러 응답 DTO
- `GeneralExceptionHandler`: @RestControllerAdvice 전역 예외 처리 (Validation, MethodNotAllowed, 500 등)

## Test plan
- [x] 컴파일 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)