### PR TITLE
feat: 상품(Product) 도메인 설계 및 엔티티 구현 (#8)

### DIFF
--- a/src/main/java/com/reservation/domain/product/entity/Product.java
+++ b/src/main/java/com/reservation/domain/product/entity/Product.java
@@ -1,0 +1,34 @@
+package com.reservation.domain.product.entity;
+
+import com.reservation.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(nullable = false)
+    private LocalTime checkInTime;
+
+    @Column(nullable = false)
+    private LocalTime checkOutTime;
+
+    @Column(length = 500)
+    private String description;
+}

--- a/src/main/java/com/reservation/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/reservation/domain/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.reservation.domain.product.repository;
+
+import com.reservation.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/reservation/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/reservation/global/common/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.reservation.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## Summary
- `BaseEntity` 공통 엔티티 구현 (createdAt, updatedAt)
- `Product` 엔티티 구현 (상품명, 가격, 입실/퇴실 시간, 설명)
- `ProductRepository` JPA Repository 구현

## Test plan
- [x] 컴파일 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)