### PR TITLE
feat: 재고(Stock) 도메인 설계 및 엔티티 구현 (#9)

### DIFF
--- a/src/main/java/com/reservation/domain/stock/entity/Stock.java
+++ b/src/main/java/com/reservation/domain/stock/entity/Stock.java
@@ -1,0 +1,45 @@
+package com.reservation.domain.stock.entity;
+
+import com.reservation.domain.product.entity.Product;
+import com.reservation.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stock extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false, unique = true)
+    private Product product;
+
+    @Column(nullable = false)
+    private int totalQuantity;
+
+    @Column(nullable = false)
+    private int remainingQuantity;
+
+    @Version
+    private int version;
+
+    public void decrease() {
+        if (this.remainingQuantity <= 0) {
+            throw new IllegalStateException("재고가 부족합니다.");
+        }
+        this.remainingQuantity--;
+    }
+
+    public void increase() {
+        if (this.remainingQuantity >= this.totalQuantity) {
+            throw new IllegalStateException("재고가 총 수량을 초과할 수 없습니다.");
+        }
+        this.remainingQuantity++;
+    }
+}

--- a/src/main/java/com/reservation/domain/stock/repository/StockRepository.java
+++ b/src/main/java/com/reservation/domain/stock/repository/StockRepository.java
@@ -1,0 +1,19 @@
+package com.reservation.domain.stock.repository;
+
+import com.reservation.domain.stock.entity.Stock;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface StockRepository extends JpaRepository<Stock, Long> {
+
+    Optional<Stock> findByProductId(Long productId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Stock s WHERE s.product.id = :productId")
+    Optional<Stock> findByProductIdWithPessimisticLock(@Param("productId") Long productId);
+}


### PR DESCRIPTION
## Summary
- `Stock` 엔티티 구현 (Product 1:1, 총수량, 잔여수량, 낙관적 락 @Version)
- `decrease()`, `increase()` 비즈니스 메서드
- `StockRepository` 구현 (비관적 락 조회 메서드 포함 - Redis Fallback용)

## Test plan
- [x] 컴파일 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)