### PR TITLE
feat: 사용자(User) 및 포인트 도메인 설계 (#10)

### DIFF
--- a/src/main/java/com/reservation/domain/user/entity/User.java
+++ b/src/main/java/com/reservation/domain/user/entity/User.java
@@ -1,0 +1,38 @@
+package com.reservation.domain.user.entity;
+
+import com.reservation.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false)
+    private int pointBalance;
+
+    public void deductPoints(int amount) {
+        if (this.pointBalance < amount) {
+            throw new IllegalStateException("포인트가 부족합니다.");
+        }
+        this.pointBalance -= amount;
+    }
+
+    public void restorePoints(int amount) {
+        this.pointBalance += amount;
+    }
+}

--- a/src/main/java/com/reservation/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/reservation/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.reservation.domain.user.repository;
+
+import com.reservation.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## Summary
- `User` 엔티티 구현 (이름, 이메일, 포인트 잔액)
- `deductPoints()`, `restorePoints()` 포인트 비즈니스 메서드
- `UserRepository` JPA Repository 구현

## Test plan
- [x] 컴파일 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)