### PR TITLE
feat: 주문(Order) 도메인 설계 및 엔티티 구현 (#11)

### DIFF
--- a/src/main/java/com/reservation/domain/order/entity/Order.java
+++ b/src/main/java/com/reservation/domain/order/entity/Order.java
@@ -1,0 +1,64 @@
+package com.reservation.domain.order.entity;
+
+import com.reservation.domain.product.entity.Product;
+import com.reservation.domain.user.entity.User;
+import com.reservation.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 30)
+    private String orderNumber;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private int totalAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OrderStatus status;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String idempotencyKey;
+
+    @Builder
+    public Order(String orderNumber, User user, Product product, int totalAmount, String idempotencyKey) {
+        this.orderNumber = orderNumber;
+        this.user = user;
+        this.product = product;
+        this.totalAmount = totalAmount;
+        this.status = OrderStatus.PENDING;
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public void complete() {
+        this.status = OrderStatus.COMPLETED;
+    }
+
+    public void fail() {
+        this.status = OrderStatus.FAILED;
+    }
+
+    public void cancel() {
+        this.status = OrderStatus.CANCELLED;
+    }
+}

--- a/src/main/java/com/reservation/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/reservation/domain/order/entity/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.reservation.domain.order.entity;
+
+public enum OrderStatus {
+    PENDING,
+    COMPLETED,
+    FAILED,
+    CANCELLED
+}

--- a/src/main/java/com/reservation/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/reservation/domain/order/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.reservation.domain.order.repository;
+
+import com.reservation.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    Optional<Order> findByIdempotencyKey(String idempotencyKey);
+}


### PR DESCRIPTION
## Summary
- `OrderStatus` enum (PENDING, COMPLETED, FAILED, CANCELLED)
- `Order` 엔티티 구현 (주문번호, User/Product 연관, 총 금액, 상태, 멱등성 키)
- `complete()`, `fail()`, `cancel()` 상태 변경 메서드
- `OrderRepository` 구현 (멱등성 키 조회 포함)

## Test plan
- [x] 컴파일 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)