### PR TITLE
feat: 결제(Payment) 도메인 설계 및 엔티티 구현 (#12)

### DIFF
--- a/src/main/java/com/reservation/domain/payment/entity/Payment.java
+++ b/src/main/java/com/reservation/domain/payment/entity/Payment.java
@@ -1,0 +1,58 @@
+package com.reservation.domain.payment.entity;
+
+import com.reservation.domain.order.entity.Order;
+import com.reservation.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentMethod paymentMethod;
+
+    @Column(nullable = false)
+    private int amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentStatus status;
+
+    @Column(length = 100)
+    private String transactionId;
+
+    @Builder
+    public Payment(Order order, PaymentMethod paymentMethod, int amount) {
+        this.order = order;
+        this.paymentMethod = paymentMethod;
+        this.amount = amount;
+        this.status = PaymentStatus.PENDING;
+    }
+
+    public void approve(String transactionId) {
+        this.status = PaymentStatus.APPROVED;
+        this.transactionId = transactionId;
+    }
+
+    public void fail() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    public void cancel() {
+        this.status = PaymentStatus.CANCELLED;
+    }
+}

--- a/src/main/java/com/reservation/domain/payment/entity/PaymentMethod.java
+++ b/src/main/java/com/reservation/domain/payment/entity/PaymentMethod.java
@@ -1,0 +1,7 @@
+package com.reservation.domain.payment.entity;
+
+public enum PaymentMethod {
+    CREDIT_CARD,
+    Y_PAY,
+    Y_POINT
+}

--- a/src/main/java/com/reservation/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/reservation/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.reservation.domain.payment.entity;
+
+public enum PaymentStatus {
+    PENDING,
+    APPROVED,
+    FAILED,
+    CANCELLED
+}

--- a/src/main/java/com/reservation/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/reservation/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,11 @@
+package com.reservation.domain.payment.repository;
+
+import com.reservation.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    List<Payment> findByOrderId(Long orderId);
+}


### PR DESCRIPTION
## Summary
- `PaymentMethod` enum (CREDIT_CARD, Y_PAY, Y_POINT)
- `PaymentStatus` enum (PENDING, APPROVED, FAILED, CANCELLED)
- `Payment` 엔티티 구현 (Order 연관, 결제수단, 금액, 상태, PG 거래 ID)
- `approve()`, `fail()`, `cancel()` 상태 변경 메서드
- `PaymentRepository` 구현 (주문별 결제 내역 조회)

## Test plan
- [x] 컴파일 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)