### PR TITLE
feat: if-else 기반 단일/복합 결제 구현 (#59)

### DIFF
--- a/src/main/java/com/reservation/domain/payment/dto/PaymentRequest.java
+++ b/src/main/java/com/reservation/domain/payment/dto/PaymentRequest.java
@@ -1,0 +1,11 @@
+package com.reservation.domain.payment.dto;
+
+import com.reservation.domain.payment.entity.PaymentMethod;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record PaymentRequest(
+        @NotNull PaymentMethod paymentMethod,
+        @Positive int amount
+) {
+}

--- a/src/main/java/com/reservation/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/reservation/domain/payment/dto/PaymentResponse.java
@@ -1,0 +1,23 @@
+package com.reservation.domain.payment.dto;
+
+import com.reservation.domain.payment.entity.Payment;
+import com.reservation.domain.payment.entity.PaymentMethod;
+import com.reservation.domain.payment.entity.PaymentStatus;
+
+public record PaymentResponse(
+        Long paymentId,
+        PaymentMethod paymentMethod,
+        int amount,
+        PaymentStatus status,
+        String transactionId
+) {
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(
+                payment.getId(),
+                payment.getPaymentMethod(),
+                payment.getAmount(),
+                payment.getStatus(),
+                payment.getTransactionId()
+        );
+    }
+}

--- a/src/main/java/com/reservation/domain/payment/pg/MockPgClient.java
+++ b/src/main/java/com/reservation/domain/payment/pg/MockPgClient.java
@@ -1,0 +1,21 @@
+package com.reservation.domain.payment.pg;
+
+import com.reservation.domain.payment.entity.PaymentMethod;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class MockPgClient implements PgClient {
+
+    @Override
+    public PgPaymentResult pay(PaymentMethod method, int amount) {
+        String transactionId = "TXN-" + UUID.randomUUID().toString().substring(0, 8);
+        return PgPaymentResult.success(transactionId);
+    }
+
+    @Override
+    public void cancel(String transactionId) {
+        // Mock: 취소 처리 완료
+    }
+}

--- a/src/main/java/com/reservation/domain/payment/pg/MockPgClient.java
+++ b/src/main/java/com/reservation/domain/payment/pg/MockPgClient.java
@@ -10,8 +10,7 @@ public class MockPgClient implements PgClient {
 
     @Override
     public PgPaymentResult pay(PaymentMethod method, int amount) {
-        String transactionId = "TXN-" + UUID.randomUUID().toString().substring(0, 8);
-        return PgPaymentResult.success(transactionId);
+        return PgPaymentResult.success(UUID.randomUUID().toString());
     }
 
     @Override

--- a/src/main/java/com/reservation/domain/payment/pg/PgClient.java
+++ b/src/main/java/com/reservation/domain/payment/pg/PgClient.java
@@ -1,0 +1,10 @@
+package com.reservation.domain.payment.pg;
+
+import com.reservation.domain.payment.entity.PaymentMethod;
+
+public interface PgClient {
+
+    PgPaymentResult pay(PaymentMethod method, int amount);
+
+    void cancel(String transactionId);
+}

--- a/src/main/java/com/reservation/domain/payment/pg/PgPaymentResult.java
+++ b/src/main/java/com/reservation/domain/payment/pg/PgPaymentResult.java
@@ -1,0 +1,15 @@
+package com.reservation.domain.payment.pg;
+
+public record PgPaymentResult(
+        boolean success,
+        String transactionId,
+        String failureReason
+) {
+    public static PgPaymentResult success(String transactionId) {
+        return new PgPaymentResult(true, transactionId, null);
+    }
+
+    public static PgPaymentResult failure(String reason) {
+        return new PgPaymentResult(false, null, reason);
+    }
+}

--- a/src/main/java/com/reservation/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/domain/payment/service/PaymentService.java
@@ -1,6 +1,7 @@
 package com.reservation.domain.payment.service;
 
 import com.reservation.domain.order.entity.Order;
+import com.reservation.domain.payment.dto.PaymentRequest;
 import com.reservation.domain.payment.entity.Payment;
 import com.reservation.domain.payment.entity.PaymentMethod;
 import com.reservation.domain.payment.pg.PgClient;
@@ -14,6 +15,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
@@ -23,37 +30,80 @@ public class PaymentService {
     private final PgClient pgClient;
 
     @Transactional
-    public Payment pay(Order order, PaymentMethod method, int amount) {
-        Payment payment = Payment.builder()
-                .order(order)
-                .paymentMethod(method)
-                .amount(amount)
-                .build();
+    public List<Payment> pay(Order order, List<PaymentRequest> requests) {
+        // 조합 검증
+        Set<PaymentMethod> methods = requests.stream()
+                .map(PaymentRequest::paymentMethod)
+                .collect(Collectors.toSet());
 
-        if (method == PaymentMethod.Y_POINT) {
-            User user = userRepository.findById(order.getUser().getId())
-                    .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
-
-            if (user.getPointBalance() < amount) {
-                payment.fail();
-                paymentRepository.save(payment);
-                throw new GeneralException(ErrorCode.INSUFFICIENT_POINTS);
-            }
-
-            user.deductPoints(amount);
-            payment.approve("POINT-" + payment.hashCode());
-        } else if (method == PaymentMethod.CREDIT_CARD || method == PaymentMethod.Y_PAY) {
-            PgPaymentResult result = pgClient.pay(method, amount);
-
-            if (!result.success()) {
-                payment.fail();
-                paymentRepository.save(payment);
-                throw new GeneralException(ErrorCode.PAYMENT_FAILED);
-            }
-
-            payment.approve(result.transactionId());
+        if (methods.contains(PaymentMethod.CREDIT_CARD) && methods.contains(PaymentMethod.Y_PAY)) {
+            throw new GeneralException(ErrorCode.INVALID_PAYMENT_COMBINATION);
         }
 
-        return paymentRepository.save(payment);
+        // 포인트 먼저, PG 나중에 처리하기 위해 분리
+        List<PaymentRequest> sorted = new ArrayList<>();
+        for (PaymentRequest request : requests) {
+            if (request.paymentMethod() == PaymentMethod.Y_POINT) {
+                sorted.add(0, request);
+            } else {
+                sorted.add(request);
+            }
+        }
+
+        List<Payment> completedPayments = new ArrayList<>();
+
+        try {
+            for (PaymentRequest request : sorted) {
+                Payment payment = Payment.builder()
+                        .order(order)
+                        .paymentMethod(request.paymentMethod())
+                        .amount(request.amount())
+                        .build();
+
+                if (request.paymentMethod() == PaymentMethod.Y_POINT) {
+                    User user = userRepository.findById(order.getUser().getId())
+                            .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+
+                    if (user.getPointBalance() < request.amount()) {
+                        payment.fail();
+                        paymentRepository.save(payment);
+                        throw new GeneralException(ErrorCode.INSUFFICIENT_POINTS);
+                    }
+
+                    user.deductPoints(request.amount());
+                    payment.approve(UUID.randomUUID().toString());
+
+                } else if (request.paymentMethod() == PaymentMethod.CREDIT_CARD
+                        || request.paymentMethod() == PaymentMethod.Y_PAY) {
+                    PgPaymentResult result = pgClient.pay(request.paymentMethod(), request.amount());
+
+                    if (!result.success()) {
+                        payment.fail();
+                        paymentRepository.save(payment);
+                        throw new GeneralException(ErrorCode.PAYMENT_FAILED);
+                    }
+
+                    payment.approve(result.transactionId());
+                }
+
+                paymentRepository.save(payment);
+                completedPayments.add(payment);
+            }
+        } catch (GeneralException e) {
+            // 보상 트랜잭션: 이미 완료된 결제 롤백
+            for (Payment completed : completedPayments) {
+                if (completed.getPaymentMethod() == PaymentMethod.Y_POINT) {
+                    User user = userRepository.findById(order.getUser().getId()).orElseThrow();
+                    user.restorePoints(completed.getAmount());
+                } else {
+                    pgClient.cancel(completed.getTransactionId());
+                }
+                completed.cancel();
+                paymentRepository.save(completed);
+            }
+            throw e;
+        }
+
+        return completedPayments;
     }
 }

--- a/src/main/java/com/reservation/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/domain/payment/service/PaymentService.java
@@ -1,0 +1,59 @@
+package com.reservation.domain.payment.service;
+
+import com.reservation.domain.order.entity.Order;
+import com.reservation.domain.payment.entity.Payment;
+import com.reservation.domain.payment.entity.PaymentMethod;
+import com.reservation.domain.payment.pg.PgClient;
+import com.reservation.domain.payment.pg.PgPaymentResult;
+import com.reservation.domain.payment.repository.PaymentRepository;
+import com.reservation.domain.user.entity.User;
+import com.reservation.domain.user.repository.UserRepository;
+import com.reservation.global.exception.GeneralException;
+import com.reservation.global.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final UserRepository userRepository;
+    private final PgClient pgClient;
+
+    @Transactional
+    public Payment pay(Order order, PaymentMethod method, int amount) {
+        Payment payment = Payment.builder()
+                .order(order)
+                .paymentMethod(method)
+                .amount(amount)
+                .build();
+
+        if (method == PaymentMethod.Y_POINT) {
+            User user = userRepository.findById(order.getUser().getId())
+                    .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+
+            if (user.getPointBalance() < amount) {
+                payment.fail();
+                paymentRepository.save(payment);
+                throw new GeneralException(ErrorCode.INSUFFICIENT_POINTS);
+            }
+
+            user.deductPoints(amount);
+            payment.approve("POINT-" + payment.hashCode());
+        } else if (method == PaymentMethod.CREDIT_CARD || method == PaymentMethod.Y_PAY) {
+            PgPaymentResult result = pgClient.pay(method, amount);
+
+            if (!result.success()) {
+                payment.fail();
+                paymentRepository.save(payment);
+                throw new GeneralException(ErrorCode.PAYMENT_FAILED);
+            }
+
+            payment.approve(result.transactionId());
+        }
+
+        return paymentRepository.save(payment);
+    }
+}

--- a/src/main/java/com/reservation/domain/user/entity/User.java
+++ b/src/main/java/com/reservation/domain/user/entity/User.java
@@ -25,6 +25,14 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private int pointBalance;
 
+    public static User create(String name, String email, int pointBalance) {
+        User user = new User();
+        user.name = name;
+        user.email = email;
+        user.pointBalance = pointBalance;
+        return user;
+    }
+
     public void deductPoints(int amount) {
         if (this.pointBalance < amount) {
             throw new IllegalStateException("포인트가 부족합니다.");

--- a/src/main/java/com/reservation/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/reservation/global/exception/code/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     // Payment
     PAYMENT_FAILED(500, "PAYMENT001", "결제에 실패했습니다."),
     INSUFFICIENT_POINTS(400, "PAYMENT002", "포인트가 부족합니다."),
+    INVALID_PAYMENT_COMBINATION(400, "PAYMENT003", "신용카드와 Y페이는 함께 사용할 수 없습니다."),
 
     // User
     USER_NOT_FOUND(404, "USER001", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/reservation/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/reservation/global/exception/code/ErrorCode.java
@@ -22,6 +22,10 @@ public enum ErrorCode {
     STOCK_SOLD_OUT(409, "STOCK002", "재고가 부족합니다."),
     STOCK_EXCEEDED(409, "STOCK003", "재고가 총 수량을 초과할 수 없습니다."),
 
+    // Payment
+    PAYMENT_FAILED(500, "PAYMENT001", "결제에 실패했습니다."),
+    INSUFFICIENT_POINTS(400, "PAYMENT002", "포인트가 부족합니다."),
+
     // User
     USER_NOT_FOUND(404, "USER001", "사용자를 찾을 수 없습니다."),
     ;

--- a/src/test/java/com/reservation/ReservationApplicationTests.java
+++ b/src/test/java/com/reservation/ReservationApplicationTests.java
@@ -1,12 +1,9 @@
 package com.reservation;
 
+import com.reservation.support.IntegrationTestSupport;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class ReservationApplicationTests {
+class ReservationApplicationTests extends IntegrationTestSupport {
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/reservation/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/PaymentServiceTest.java
@@ -2,9 +2,11 @@ package com.reservation.domain.payment.service;
 
 import com.reservation.domain.order.entity.Order;
 import com.reservation.domain.order.repository.OrderRepository;
+import com.reservation.domain.payment.dto.PaymentRequest;
 import com.reservation.domain.payment.entity.Payment;
 import com.reservation.domain.payment.entity.PaymentMethod;
 import com.reservation.domain.payment.entity.PaymentStatus;
+import com.reservation.domain.payment.repository.PaymentRepository;
 import com.reservation.domain.product.entity.Product;
 import com.reservation.domain.product.repository.ProductRepository;
 import com.reservation.domain.user.entity.User;
@@ -14,10 +16,12 @@ import com.reservation.global.exception.code.ErrorCode;
 import com.reservation.support.IntegrationTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -36,11 +40,11 @@ class PaymentServiceTest extends IntegrationTestSupport {
     @Autowired
     private OrderRepository orderRepository;
 
+    @Autowired
+    private PaymentRepository paymentRepository;
+
     private Order order;
     private User user;
-
-    @Autowired
-    private com.reservation.domain.payment.repository.PaymentRepository paymentRepository;
 
     @BeforeEach
     void setUp() {
@@ -66,40 +70,116 @@ class PaymentServiceTest extends IntegrationTestSupport {
                 .build());
     }
 
-    @DisplayName("신용카드 결제 성공")
-    @Test
-    void creditCardPaymentSucceeds() {
-        Payment payment = paymentService.pay(order, PaymentMethod.CREDIT_CARD, 100000);
+    @Nested
+    @DisplayName("단일 결제")
+    class SinglePayment {
 
-        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.APPROVED);
-        assertThat(payment.getTransactionId()).startsWith("TXN-");
+        @DisplayName("신용카드 결제 성공")
+        @Test
+        void creditCardPaymentSucceeds() {
+            List<Payment> payments = paymentService.pay(order,
+                    List.of(new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)));
+
+            assertThat(payments).hasSize(1);
+            assertThat(payments.get(0).getStatus()).isEqualTo(PaymentStatus.APPROVED);
+            assertThat(payments.get(0).getTransactionId()).isNotNull();
+        }
+
+        @DisplayName("Y페이 결제 성공")
+        @Test
+        void yPayPaymentSucceeds() {
+            List<Payment> payments = paymentService.pay(order,
+                    List.of(new PaymentRequest(PaymentMethod.Y_PAY, 100000)));
+
+            assertThat(payments).hasSize(1);
+            assertThat(payments.get(0).getStatus()).isEqualTo(PaymentStatus.APPROVED);
+        }
+
+        @DisplayName("Y포인트 결제 성공 시 잔액 차감")
+        @Test
+        void yPointPaymentSucceeds() {
+            List<Payment> payments = paymentService.pay(order,
+                    List.of(new PaymentRequest(PaymentMethod.Y_POINT, 30000)));
+
+            assertThat(payments).hasSize(1);
+            assertThat(payments.get(0).getStatus()).isEqualTo(PaymentStatus.APPROVED);
+            User updatedUser = userRepository.findById(user.getId()).orElseThrow();
+            assertThat(updatedUser.getPointBalance()).isEqualTo(20000);
+        }
+
+        @DisplayName("Y포인트 잔액 부족 시 결제 실패")
+        @Test
+        void yPointPaymentFailsWhenInsufficientBalance() {
+            assertThatThrownBy(() -> paymentService.pay(order,
+                    List.of(new PaymentRequest(PaymentMethod.Y_POINT, 60000))))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                            .isEqualTo(ErrorCode.INSUFFICIENT_POINTS));
+        }
     }
 
-    @DisplayName("Y페이 결제 성공")
-    @Test
-    void yPayPaymentSucceeds() {
-        Payment payment = paymentService.pay(order, PaymentMethod.Y_PAY, 100000);
+    @Nested
+    @DisplayName("복합 결제")
+    class CompositePayment {
 
-        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.APPROVED);
-        assertThat(payment.getTransactionId()).startsWith("TXN-");
+        @DisplayName("신용카드 + Y포인트 복합 결제 성공")
+        @Test
+        void creditCardWithPointSucceeds() {
+            List<Payment> payments = paymentService.pay(order, List.of(
+                    new PaymentRequest(PaymentMethod.Y_POINT, 30000),
+                    new PaymentRequest(PaymentMethod.CREDIT_CARD, 70000)
+            ));
+
+            assertThat(payments).hasSize(2);
+            assertThat(payments).allMatch(p -> p.getStatus() == PaymentStatus.APPROVED);
+            User updatedUser = userRepository.findById(user.getId()).orElseThrow();
+            assertThat(updatedUser.getPointBalance()).isEqualTo(20000);
+        }
+
+        @DisplayName("Y페이 + Y포인트 복합 결제 성공")
+        @Test
+        void yPayWithPointSucceeds() {
+            List<Payment> payments = paymentService.pay(order, List.of(
+                    new PaymentRequest(PaymentMethod.Y_POINT, 20000),
+                    new PaymentRequest(PaymentMethod.Y_PAY, 80000)
+            ));
+
+            assertThat(payments).hasSize(2);
+            assertThat(payments).allMatch(p -> p.getStatus() == PaymentStatus.APPROVED);
+            User updatedUser = userRepository.findById(user.getId()).orElseThrow();
+            assertThat(updatedUser.getPointBalance()).isEqualTo(30000);
+        }
     }
 
-    @DisplayName("Y포인트 결제 성공 시 잔액 차감")
-    @Test
-    void yPointPaymentSucceeds() {
-        Payment payment = paymentService.pay(order, PaymentMethod.Y_POINT, 30000);
+    @Nested
+    @DisplayName("결제 조합 검증")
+    class PaymentCombinationValidation {
 
-        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.APPROVED);
-        User updatedUser = userRepository.findById(user.getId()).orElseThrow();
-        assertThat(updatedUser.getPointBalance()).isEqualTo(20000);
-    }
+        @DisplayName("신용카드 + Y페이 혼용 불가")
+        @Test
+        void creditCardAndYPayCombinationFails() {
+            assertThatThrownBy(() -> paymentService.pay(order, List.of(
+                    new PaymentRequest(PaymentMethod.CREDIT_CARD, 50000),
+                    new PaymentRequest(PaymentMethod.Y_PAY, 50000)
+            )))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_PAYMENT_COMBINATION));
+        }
 
-    @DisplayName("Y포인트 잔액 부족 시 결제 실패")
-    @Test
-    void yPointPaymentFailsWhenInsufficientBalance() {
-        assertThatThrownBy(() -> paymentService.pay(order, PaymentMethod.Y_POINT, 60000))
-                .isInstanceOf(GeneralException.class)
-                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
-                        .isEqualTo(ErrorCode.INSUFFICIENT_POINTS));
+        @DisplayName("복합 결제 중 PG 실패 시 포인트 환불")
+        @Test
+        void rollbackPointWhenPgFails() {
+            // MockPgClient는 항상 성공하므로 이 테스트는 Strategy 패턴 전환 후 Mock 주입으로 검증
+            // 여기서는 포인트 먼저 차감 → 카드 성공 흐름만 확인
+            List<Payment> payments = paymentService.pay(order, List.of(
+                    new PaymentRequest(PaymentMethod.Y_POINT, 10000),
+                    new PaymentRequest(PaymentMethod.CREDIT_CARD, 90000)
+            ));
+
+            assertThat(payments).hasSize(2);
+            User updatedUser = userRepository.findById(user.getId()).orElseThrow();
+            assertThat(updatedUser.getPointBalance()).isEqualTo(40000);
+        }
     }
 }

--- a/src/test/java/com/reservation/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,105 @@
+package com.reservation.domain.payment.service;
+
+import com.reservation.domain.order.entity.Order;
+import com.reservation.domain.order.repository.OrderRepository;
+import com.reservation.domain.payment.entity.Payment;
+import com.reservation.domain.payment.entity.PaymentMethod;
+import com.reservation.domain.payment.entity.PaymentStatus;
+import com.reservation.domain.product.entity.Product;
+import com.reservation.domain.product.repository.ProductRepository;
+import com.reservation.domain.user.entity.User;
+import com.reservation.domain.user.repository.UserRepository;
+import com.reservation.global.exception.GeneralException;
+import com.reservation.global.exception.code.ErrorCode;
+import com.reservation.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PaymentServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    private Order order;
+    private User user;
+
+    @Autowired
+    private com.reservation.domain.payment.repository.PaymentRepository paymentRepository;
+
+    @BeforeEach
+    void setUp() {
+        paymentRepository.deleteAll();
+        orderRepository.deleteAll();
+        productRepository.deleteAll();
+        userRepository.deleteAll();
+
+        user = userRepository.saveAndFlush(User.create("테스트유저", "test@test.com", 50000));
+
+        Product product = productRepository.saveAndFlush(Product.create(
+                "테스트 숙소", 100000,
+                LocalTime.of(15, 0), LocalTime.of(11, 0),
+                "결제 테스트용 상품"
+        ));
+
+        order = orderRepository.saveAndFlush(Order.builder()
+                .orderNumber("ORD-TEST-001")
+                .user(user)
+                .product(product)
+                .totalAmount(100000)
+                .idempotencyKey("test-key-001")
+                .build());
+    }
+
+    @DisplayName("신용카드 결제 성공")
+    @Test
+    void creditCardPaymentSucceeds() {
+        Payment payment = paymentService.pay(order, PaymentMethod.CREDIT_CARD, 100000);
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.APPROVED);
+        assertThat(payment.getTransactionId()).startsWith("TXN-");
+    }
+
+    @DisplayName("Y페이 결제 성공")
+    @Test
+    void yPayPaymentSucceeds() {
+        Payment payment = paymentService.pay(order, PaymentMethod.Y_PAY, 100000);
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.APPROVED);
+        assertThat(payment.getTransactionId()).startsWith("TXN-");
+    }
+
+    @DisplayName("Y포인트 결제 성공 시 잔액 차감")
+    @Test
+    void yPointPaymentSucceeds() {
+        Payment payment = paymentService.pay(order, PaymentMethod.Y_POINT, 30000);
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.APPROVED);
+        User updatedUser = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(updatedUser.getPointBalance()).isEqualTo(20000);
+    }
+
+    @DisplayName("Y포인트 잔액 부족 시 결제 실패")
+    @Test
+    void yPointPaymentFailsWhenInsufficientBalance() {
+        assertThatThrownBy(() -> paymentService.pay(order, PaymentMethod.Y_POINT, 60000))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.INSUFFICIENT_POINTS));
+    }
+}

--- a/src/test/java/com/reservation/domain/stock/service/StockServiceConcurrencyTest.java
+++ b/src/test/java/com/reservation/domain/stock/service/StockServiceConcurrencyTest.java
@@ -1,5 +1,7 @@
 package com.reservation.domain.stock.service;
 
+import com.reservation.domain.order.repository.OrderRepository;
+import com.reservation.domain.payment.repository.PaymentRepository;
 import com.reservation.domain.product.entity.Product;
 import com.reservation.domain.product.repository.ProductRepository;
 import com.reservation.domain.stock.entity.Stock;
@@ -41,10 +43,10 @@ class StockServiceConcurrencyTest extends IntegrationTestSupport {
     private RedisStockService redisStockService;
 
     @Autowired
-    private com.reservation.domain.payment.repository.PaymentRepository paymentRepository;
+    private PaymentRepository paymentRepository;
 
     @Autowired
-    private com.reservation.domain.order.repository.OrderRepository orderRepository;
+    private OrderRepository orderRepository;
 
     @Autowired
     private ProductRepository productRepository;

--- a/src/test/java/com/reservation/domain/stock/service/StockServiceConcurrencyTest.java
+++ b/src/test/java/com/reservation/domain/stock/service/StockServiceConcurrencyTest.java
@@ -6,19 +6,13 @@ import com.reservation.domain.stock.entity.Stock;
 import com.reservation.domain.stock.repository.StockRepository;
 import com.reservation.global.exception.GeneralException;
 import com.reservation.global.exception.code.ErrorCode;
-import com.redis.testcontainers.RedisContainer;
+import com.reservation.support.IntegrationTestSupport;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -33,19 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Testcontainers
-class StockServiceConcurrencyTest {
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
-            .withDatabaseName("reservation_test");
-
-    @Container
-    @ServiceConnection
-    static RedisContainer redis = new RedisContainer(DockerImageName.parse("redis:7"));
+class StockServiceConcurrencyTest extends IntegrationTestSupport {
 
     private static final int TOTAL_STOCK = 10;
 
@@ -59,6 +41,12 @@ class StockServiceConcurrencyTest {
     private RedisStockService redisStockService;
 
     @Autowired
+    private com.reservation.domain.payment.repository.PaymentRepository paymentRepository;
+
+    @Autowired
+    private com.reservation.domain.order.repository.OrderRepository orderRepository;
+
+    @Autowired
     private ProductRepository productRepository;
 
     @Autowired
@@ -68,6 +56,8 @@ class StockServiceConcurrencyTest {
 
     @BeforeEach
     void setUp() {
+        paymentRepository.deleteAll();
+        orderRepository.deleteAll();
         stockRepository.deleteAll();
         productRepository.deleteAll();
 
@@ -144,7 +134,9 @@ class StockServiceConcurrencyTest {
     }
 
     @Nested
+    @DisplayName("비관적 락")
     class PessimisticLock {
+        @DisplayName("초과판매 방지")
         @ParameterizedTest
         @ValueSource(ints = {100, 1000})
         void preventsOverselling(int requestCount) throws Exception {
@@ -157,7 +149,9 @@ class StockServiceConcurrencyTest {
     }
 
     @Nested
+    @DisplayName("낙관적 락")
     class OptimisticLock {
+        @DisplayName("초과판매 방지")
         @ParameterizedTest
         @ValueSource(ints = {100, 1000})
         void preventsOverselling(int requestCount) throws Exception {
@@ -170,12 +164,14 @@ class StockServiceConcurrencyTest {
     }
 
     @Nested
+    @DisplayName("Redis Lua 스크립트")
     class RedisLua {
         @BeforeEach
         void setUpRedis() {
             redisStockService.initStock(productId, TOTAL_STOCK);
         }
 
+        @DisplayName("초과판매 방지")
         @ParameterizedTest
         @ValueSource(ints = {100, 1000})
         void preventsOverselling(int requestCount) throws Exception {

--- a/src/test/java/com/reservation/support/IntegrationTestSupport.java
+++ b/src/test/java/com/reservation/support/IntegrationTestSupport.java
@@ -1,0 +1,33 @@
+package com.reservation.support;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class IntegrationTestSupport {
+
+    static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("reservation_test");
+
+    static final RedisContainer redis = new RedisContainer(DockerImageName.parse("redis:7"));
+
+    static {
+        mysql.start();
+        redis.start();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+    }
+}


### PR DESCRIPTION
## Summary
- if-else 분기 기반 `PaymentService` 구현 (단일/복합 결제, 조합 검증, 보상 트랜잭션)
- `PgClient` 인터페이스 및 `MockPgClient` 구현
- `IntegrationTestSupport` 공통 테스트 설정 추출 (Testcontainers 공유)
- `@DisplayName` 테스트 네이밍 컨벤션 적용

## 결제 지원 범위

| 결제 방식 | 지원 |
|---------|------|
| 신용카드 단독 | O |
| Y페이 단독 | O |
| Y포인트 단독 | O |
| 신용카드 + Y포인트 | O |
| Y페이 + Y포인트 | O |
| 신용카드 + Y페이 | X (검증 차단) |

## Test plan
- [x] 단일 결제: 신용카드/Y페이/Y포인트 성공, 포인트 부족 실패
- [x] 복합 결제: 카드+포인트, Y페이+포인트 성공
- [x] 조합 검증: 카드+Y페이 혼용 시 예외
- [x] 기존 StockServiceConcurrencyTest 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)