### PR TITLE
feat: 기본 Booking API 구현 (#62)

### DIFF
--- a/src/main/java/com/reservation/domain/order/controller/BookingController.java
+++ b/src/main/java/com/reservation/domain/order/controller/BookingController.java
@@ -1,0 +1,27 @@
+package com.reservation.domain.order.controller;
+
+import com.reservation.domain.order.dto.BookingRequest;
+import com.reservation.domain.order.dto.BookingResponse;
+import com.reservation.domain.order.service.BookingService;
+import com.reservation.global.common.constants.HeaderConstants;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/bookings")
+@RequiredArgsConstructor
+public class BookingController {
+
+    private final BookingService bookingService;
+
+    @PostMapping
+    public ResponseEntity<BookingResponse> book(
+            @RequestHeader(HeaderConstants.USER_ID) Long userId,
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @Valid @RequestBody BookingRequest request) {
+        BookingResponse response = bookingService.book(userId, idempotencyKey, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/reservation/domain/order/dto/BookingRequest.java
+++ b/src/main/java/com/reservation/domain/order/dto/BookingRequest.java
@@ -1,0 +1,14 @@
+package com.reservation.domain.order.dto;
+
+import com.reservation.domain.payment.dto.PaymentRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record BookingRequest(
+        @NotNull Long productId,
+        @NotEmpty @Valid List<PaymentRequest> payments
+) {
+}

--- a/src/main/java/com/reservation/domain/order/dto/BookingResponse.java
+++ b/src/main/java/com/reservation/domain/order/dto/BookingResponse.java
@@ -1,0 +1,26 @@
+package com.reservation.domain.order.dto;
+
+import com.reservation.domain.order.entity.Order;
+import com.reservation.domain.order.entity.OrderStatus;
+import com.reservation.domain.payment.dto.PaymentResponse;
+import com.reservation.domain.payment.entity.Payment;
+
+import java.util.List;
+
+public record BookingResponse(
+        Long orderId,
+        String orderNumber,
+        int totalAmount,
+        OrderStatus orderStatus,
+        List<PaymentResponse> payments
+) {
+    public static BookingResponse of(Order order, List<Payment> payments) {
+        return new BookingResponse(
+                order.getId(),
+                order.getOrderNumber(),
+                order.getTotalAmount(),
+                order.getStatus(),
+                payments.stream().map(PaymentResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -1,0 +1,71 @@
+package com.reservation.domain.order.service;
+
+import com.reservation.domain.order.dto.BookingRequest;
+import com.reservation.domain.order.dto.BookingResponse;
+import com.reservation.domain.order.entity.Order;
+import com.reservation.domain.order.repository.OrderRepository;
+import com.reservation.domain.payment.entity.Payment;
+import com.reservation.domain.payment.service.PaymentService;
+import com.reservation.domain.product.entity.Product;
+import com.reservation.domain.product.service.ProductService;
+import com.reservation.domain.stock.service.RedisStockService;
+import com.reservation.domain.stock.service.StockService;
+import com.reservation.domain.user.entity.User;
+import com.reservation.domain.user.service.UserService;
+import com.reservation.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BookingService {
+
+    private final ProductService productService;
+    private final UserService userService;
+    private final RedisStockService redisStockService;
+    private final StockService stockService;
+    private final OrderRepository orderRepository;
+    private final PaymentService paymentService;
+    private final OrderNumberGenerator orderNumberGenerator;
+
+    public BookingResponse book(Long userId, String idempotencyKey, BookingRequest request) {
+        Product product = productService.getProduct(request.productId());
+        User user = userService.getUser(userId);
+
+        // 1. Redis 재고 차감
+        redisStockService.decrease(product.getId());
+
+        try {
+            // 2. 주문 생성 + 결제 + 확정 (트랜잭션)
+            return processOrder(user, product, idempotencyKey, request);
+        } catch (GeneralException e) {
+            // 3. 결제 실패 시 Redis 재고 복구
+            redisStockService.increase(product.getId());
+            throw e;
+        }
+    }
+
+    @Transactional
+    protected BookingResponse processOrder(User user, Product product, String idempotencyKey, BookingRequest request) {
+        Order order = Order.builder()
+                .orderNumber(orderNumberGenerator.generate())
+                .user(user)
+                .product(product)
+                .totalAmount(product.getPrice())
+                .idempotencyKey(idempotencyKey)
+                .build();
+        orderRepository.save(order);
+
+        // 결제
+        List<Payment> payments = paymentService.pay(order, request.payments());
+
+        // DB 재고 차감 + 주문 확정
+        stockService.decreaseWithPessimisticLock(product.getId());
+        order.complete();
+
+        return BookingResponse.of(order, payments);
+    }
+}

--- a/src/main/java/com/reservation/domain/order/service/OrderNumberGenerator.java
+++ b/src/main/java/com/reservation/domain/order/service/OrderNumberGenerator.java
@@ -4,17 +4,16 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.UUID;
 
 @Component
 public class OrderNumberGenerator {
 
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
-    private final AtomicLong sequence = new AtomicLong(0);
 
     public String generate() {
         String date = LocalDate.now().format(DATE_FORMAT);
-        long seq = sequence.incrementAndGet();
-        return String.format("ORD-%s-%06d", date, seq);
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        return String.format("ORD-%s-%s", date, uuid);
     }
 }

--- a/src/main/java/com/reservation/domain/order/service/OrderNumberGenerator.java
+++ b/src/main/java/com/reservation/domain/order/service/OrderNumberGenerator.java
@@ -1,0 +1,20 @@
+package com.reservation.domain.order.service;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+public class OrderNumberGenerator {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private final AtomicLong sequence = new AtomicLong(0);
+
+    public String generate() {
+        String date = LocalDate.now().format(DATE_FORMAT);
+        long seq = sequence.incrementAndGet();
+        return String.format("ORD-%s-%06d", date, seq);
+    }
+}

--- a/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
+++ b/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
@@ -27,6 +27,11 @@ public class RedisStockService {
         }
     }
 
+    public void increase(Long productId) {
+        String key = STOCK_KEY_PREFIX + productId;
+        redisTemplate.opsForValue().increment(key);
+    }
+
     public void initStock(Long productId, int quantity) {
         String key = STOCK_KEY_PREFIX + productId;
         redisTemplate.opsForValue().set(key, String.valueOf(quantity));


### PR DESCRIPTION
## Summary
- `POST /api/bookings` 엔드포인트 구현 (BookingController)
- BookingService: Redis 재고 차감 → 주문 생성(PENDING) → 결제 → DB 재고 차감 → 주문 확정(COMPLETED)
- 결제 실패 시 Redis 재고 복구 (보상 트랜잭션)
- OrderNumberGenerator: UUID 기반 (`ORD-yyyyMMdd-{uuid8}`)
- RedisStockService.increase() 추가

## Note
멱등성 처리는 #63에서 구현 예정

## Test plan
- [x] 전체 테스트 통과 확인

closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)