### PR TITLE
feat: 멱등성 키 기반 중복 요청 방지 구현 (#63)

### DIFF
--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -5,6 +5,7 @@ import com.reservation.domain.order.dto.BookingResponse;
 import com.reservation.domain.order.entity.Order;
 import com.reservation.domain.order.repository.OrderRepository;
 import com.reservation.domain.payment.entity.Payment;
+import com.reservation.domain.payment.repository.PaymentRepository;
 import com.reservation.domain.payment.service.PaymentService;
 import com.reservation.domain.product.entity.Product;
 import com.reservation.domain.product.service.ProductService;
@@ -13,6 +14,7 @@ import com.reservation.domain.stock.service.StockService;
 import com.reservation.domain.user.entity.User;
 import com.reservation.domain.user.service.UserService;
 import com.reservation.global.exception.GeneralException;
+import com.reservation.global.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,24 +30,43 @@ public class BookingService {
     private final RedisStockService redisStockService;
     private final StockService stockService;
     private final OrderRepository orderRepository;
+    private final PaymentRepository paymentRepository;
     private final PaymentService paymentService;
     private final OrderNumberGenerator orderNumberGenerator;
+    private final IdempotencyService idempotencyService;
 
     public BookingResponse book(Long userId, String idempotencyKey, BookingRequest request) {
+        // 1. 멱등성 체크 — 이미 처리된 요청이면 기존 결과 반환
+        if (idempotencyService.exists(idempotencyKey)) {
+            return getExistingOrder(idempotencyKey);
+        }
+
         Product product = productService.getProduct(request.productId());
         User user = userService.getUser(userId);
 
-        // 1. Redis 재고 차감
+        // 2. Redis 재고 차감
         redisStockService.decrease(product.getId());
 
         try {
-            // 2. 주문 생성 + 결제 + 확정 (트랜잭션)
-            return processOrder(user, product, idempotencyKey, request);
+            // 3. 주문 생성 + 결제 + 확정 (트랜잭션)
+            BookingResponse response = processOrder(user, product, idempotencyKey, request);
+
+            // 4. 멱등성 키 저장
+            idempotencyService.save(idempotencyKey);
+
+            return response;
         } catch (GeneralException e) {
-            // 3. 결제 실패 시 Redis 재고 복구
+            // 결제 실패 시 Redis 재고 복구
             redisStockService.increase(product.getId());
             throw e;
         }
+    }
+
+    private BookingResponse getExistingOrder(String idempotencyKey) {
+        Order order = orderRepository.findByIdempotencyKey(idempotencyKey)
+                .orElseThrow(() -> new GeneralException(ErrorCode.DUPLICATE_ORDER));
+        List<Payment> payments = paymentRepository.findByOrderId(order.getId());
+        return BookingResponse.of(order, payments);
     }
 
     @Transactional

--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -36,7 +36,6 @@ public class BookingService {
     private final IdempotencyService idempotencyService;
 
     public BookingResponse book(Long userId, String idempotencyKey, BookingRequest request) {
-        // 1. 멱등성 체크 — 이미 처리된 요청이면 기존 결과 반환
         if (idempotencyService.exists(idempotencyKey)) {
             return getExistingOrder(idempotencyKey);
         }
@@ -44,19 +43,13 @@ public class BookingService {
         Product product = productService.getProduct(request.productId());
         User user = userService.getUser(userId);
 
-        // 2. Redis 재고 차감
         redisStockService.decrease(product.getId());
 
         try {
-            // 3. 주문 생성 + 결제 + 확정 (트랜잭션)
             BookingResponse response = processOrder(user, product, idempotencyKey, request);
-
-            // 4. 멱등성 키 저장
             idempotencyService.save(idempotencyKey);
-
             return response;
         } catch (GeneralException e) {
-            // 결제 실패 시 Redis 재고 복구
             redisStockService.increase(product.getId());
             throw e;
         }
@@ -80,10 +73,8 @@ public class BookingService {
                 .build();
         orderRepository.save(order);
 
-        // 결제
         List<Payment> payments = paymentService.pay(order, request.payments());
 
-        // DB 재고 차감 + 주문 확정
         stockService.decreaseWithPessimisticLock(product.getId());
         order.complete();
 

--- a/src/main/java/com/reservation/domain/order/service/IdempotencyService.java
+++ b/src/main/java/com/reservation/domain/order/service/IdempotencyService.java
@@ -1,0 +1,25 @@
+package com.reservation.domain.order.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class IdempotencyService {
+
+    private static final String KEY_PREFIX = "idempotency:";
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean exists(String idempotencyKey) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + idempotencyKey));
+    }
+
+    public void save(String idempotencyKey) {
+        redisTemplate.opsForValue().set(KEY_PREFIX + idempotencyKey, "1", TTL);
+    }
+}

--- a/src/main/java/com/reservation/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/reservation/global/exception/code/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     INSUFFICIENT_POINTS(400, "PAYMENT002", "포인트가 부족합니다."),
     INVALID_PAYMENT_COMBINATION(400, "PAYMENT003", "신용카드와 Y페이는 함께 사용할 수 없습니다."),
 
+    // Order
+    DUPLICATE_ORDER(409, "ORDER001", "이미 처리된 요청입니다."),
+
     // User
     USER_NOT_FOUND(404, "USER001", "사용자를 찾을 수 없습니다."),
     ;


### PR DESCRIPTION
## Summary
- `IdempotencyService`: Redis 기반 멱등성 키 저장/조회 (TTL 24h)
- `BookingService`: 동일 키 재요청 시 기존 주문 결과 반환
- `ErrorCode.DUPLICATE_ORDER` (409) 추가

## 멱등성 처리 흐름
1. Redis에서 멱등성 키 존재 확인
2. 존재 → DB에서 기존 주문 조회 후 반환
3. 미존재 → 예약 플로우 진행 → 성공 시 Redis에 키 저장 (TTL 24h)

## Test plan
- [x] 전체 테스트 통과 확인

closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)