### PR TITLE
feat: Redis 장애 시 Fallback 구현 (#65)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -137,7 +137,43 @@ public interface PaymentStrategy {
 
 ## 쟁점 4. Redis 장애 Fallback 전략
 
-> Phase 8에서 작성 예정
+> Redis가 장애 상태일 때 서비스 중단 없이 핵심 기능을 유지하는 방법
+
+### 검토한 방식
+
+| 방식 | 핵심 원리 |
+|------|---------|
+| 서비스 중단 (fail-fast) | Redis 장애 시 즉시 에러 반환 |
+| DB Fallback | Redis 장애 감지 → DB 비관적 락으로 자동 전환 |
+| 로컬 캐시 Fallback | 서버 메모리에 재고 캐싱 |
+
+### 최종 선택: DB Fallback (비관적 락)
+
+**선택 근거**
+
+- 00시 프로모션 시간에 Redis 장애가 나면 매출 손실이 크므로, 성능 저하를 감수하더라도 서비스를 지속하는 것이 유리
+- 로컬 캐시는 분산 환경(서버 2대)에서 재고 정합성을 보장할 수 없음
+- DB 비관적 락은 단일 row 경합에서 낙관적 락보다 효율적 — 재고 10개에 1000TPS가 몰리면 성공률 1%이므로 낙관적 락의 재시도 비용이 폭증
+- Redis 복구 시 별도 전환 작업 없이 자동으로 Redis 모드로 복귀
+
+**Fallback 범위**
+
+| 기능 | 정상 시 | Redis 장애 시 |
+|------|---------|-------------|
+| 재고 관리 | Redis Lua Script | DB 비관적 락 |
+| 멱등성 체크 | Redis GET | DB UNIQUE 제약조건 |
+| 멱등성 저장 | Redis SET (TTL 24h) | 생략 (DB UNIQUE로 보장) |
+
+**구현 방식**
+
+- `RedisConnectionFailureException` catch로 장애 감지
+- `RedisStockService.decrease()`가 `boolean`(Redis 사용 여부)을 반환하여 보상 트랜잭션 시 Redis 복구 필요 여부를 판단
+- DB Fallback으로 재고를 이미 차감한 경우, `OrderTransactionService`에서 DB 재고 중복 차감을 방지
+
+**트레이드오프**
+
+- DB Fallback 시 성능 저하는 불가피하나, 재고 10개가 빠르게 소진되므로 실제 락 경합 시간은 짧음
+- 매 요청마다 Redis를 먼저 시도하므로 Redis 복구 시 자동으로 정상 모드 복귀
 
 ---
 

--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -39,14 +39,16 @@ public class BookingService {
         Product product = productService.getProduct(request.productId());
         User user = userService.getUser(userId);
 
-        redisStockService.decrease(product.getId());
+        boolean redisUsed = redisStockService.decrease(product.getId());
 
         try {
-            OrderResult result = orderTransactionService.process(user, product, idempotencyKey, request);
+            OrderResult result = orderTransactionService.process(user, product, idempotencyKey, request, redisUsed);
             idempotencyService.save(idempotencyKey);
             return BookingResponse.of(result.order(), result.payments());
         } catch (Exception e) {
-            redisStockService.increase(product.getId());
+            if (redisUsed) {
+                redisStockService.increase(product.getId());
+            }
             orderTransactionService.markFailed(idempotencyKey);
             throw e;
         }

--- a/src/main/java/com/reservation/domain/order/service/IdempotencyService.java
+++ b/src/main/java/com/reservation/domain/order/service/IdempotencyService.java
@@ -1,11 +1,15 @@
 package com.reservation.domain.order.service;
 
+import com.reservation.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class IdempotencyService {
@@ -14,12 +18,22 @@ public class IdempotencyService {
     private static final Duration TTL = Duration.ofHours(24);
 
     private final StringRedisTemplate redisTemplate;
+    private final OrderRepository orderRepository;
 
     public boolean exists(String idempotencyKey) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + idempotencyKey));
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + idempotencyKey));
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 장애 감지, DB Fallback으로 멱등성 체크: {}", e.getMessage());
+            return orderRepository.findByIdempotencyKey(idempotencyKey).isPresent();
+        }
     }
 
     public void save(String idempotencyKey) {
-        redisTemplate.opsForValue().set(KEY_PREFIX + idempotencyKey, "1", TTL);
+        try {
+            redisTemplate.opsForValue().set(KEY_PREFIX + idempotencyKey, "1", TTL);
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 장애로 멱등성 키 저장 생략 (DB UNIQUE 제약조건으로 보장): {}", e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/reservation/domain/order/service/OrderTransactionService.java
+++ b/src/main/java/com/reservation/domain/order/service/OrderTransactionService.java
@@ -24,7 +24,7 @@ public class OrderTransactionService {
     private final OrderNumberGenerator orderNumberGenerator;
 
     @Transactional
-    public OrderResult process(User user, Product product, String idempotencyKey, BookingRequest request) {
+    public OrderResult process(User user, Product product, String idempotencyKey, BookingRequest request, boolean decreaseDbStock) {
         Order order = Order.builder()
                 .orderNumber(orderNumberGenerator.generate())
                 .user(user)
@@ -36,7 +36,9 @@ public class OrderTransactionService {
 
         List<Payment> payments = paymentService.pay(order, request.payments());
 
-        stockService.decreaseWithPessimisticLock(product.getId());
+        if (decreaseDbStock) {
+            stockService.decreaseWithPessimisticLock(product.getId());
+        }
         order.complete();
 
         return new OrderResult(order, payments);

--- a/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
+++ b/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
@@ -3,12 +3,15 @@ package com.reservation.domain.stock.service;
 import com.reservation.global.exception.GeneralException;
 import com.reservation.global.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisStockService {
@@ -17,19 +20,31 @@ public class RedisStockService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisScript<Long> decreaseStockScript;
+    private final StockService stockService;
 
-    public void decrease(Long productId) {
-        String key = STOCK_KEY_PREFIX + productId;
-        Long result = redisTemplate.execute(decreaseStockScript, List.of(key));
+    public boolean decrease(Long productId) {
+        try {
+            String key = STOCK_KEY_PREFIX + productId;
+            Long result = redisTemplate.execute(decreaseStockScript, List.of(key));
 
-        if (result == 0L) {
-            throw new GeneralException(ErrorCode.STOCK_SOLD_OUT);
+            if (result == 0L) {
+                throw new GeneralException(ErrorCode.STOCK_SOLD_OUT);
+            }
+            return true;
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 장애 감지, DB Fallback으로 전환: {}", e.getMessage());
+            stockService.decreaseWithPessimisticLock(productId);
+            return false;
         }
     }
 
     public void increase(Long productId) {
-        String key = STOCK_KEY_PREFIX + productId;
-        redisTemplate.opsForValue().increment(key);
+        try {
+            String key = STOCK_KEY_PREFIX + productId;
+            redisTemplate.opsForValue().increment(key);
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 장애로 재고 복구 생략 (DB 트랜잭션 롤백으로 처리): {}", e.getMessage());
+        }
     }
 
     public void initStock(Long productId, int quantity) {


### PR DESCRIPTION
## Summary
- `RedisStockService`: Redis 장애 감지 → DB 비관적 락으로 재고 차감 전환
- `IdempotencyService`: Redis 장애 → DB UNIQUE 제약조건으로 멱등성 체크
- `BookingService`: `redisUsed` 플래그로 보상 시 Redis 복구 여부 판단
- `OrderTransactionService`: Fallback 시 DB 재고 중복 차감 방지
- DECISIONS.md 쟁점 4 (Redis 장애 Fallback 전략) 작성

## Fallback 범위
| 기능 | 정상 시 | Redis 장애 시 |
|------|---------|-------------|
| 재고 관리 | Redis Lua Script | DB 비관적 락 |
| 멱등성 체크 | Redis GET | DB UNIQUE 제약조건 |
| 멱등성 저장 | Redis SET (TTL 24h) | 생략 (DB로 보장) |

## Test plan
- [x] 전체 테스트 통과 확인

closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)