### PR TITLE
feat: 서킷브레이커 적용 - Resilience4j (#67)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -185,7 +185,39 @@ public interface PaymentStrategy {
 
 ## 쟁점 6. 결제 실패 케이스별 대응 전략
 
-> Phase 8에서 작성 예정
+> 외부 결제 연동 장애 시 서버 전체가 멈추지 않도록 보호하는 방법
+
+### 결제 실패 케이스 분류
+
+| 실패 유형 | 원인 | ErrorCode | HTTP |
+|----------|------|-----------|------|
+| 한도 초과 | 사용자 결제 한도 초과 | PAYMENT_LIMIT_EXCEEDED | 400 |
+| 타임아웃 | PG/Y페이 응답 지연 | PAYMENT_TIMEOUT | 503 |
+| 네트워크 오류 | 연결 실패, 예외 발생 | PAYMENT_TIMEOUT | 503 |
+| 서킷 오픈 | 장애 누적으로 서킷브레이커 차단 | PAYMENT_TIMEOUT | 503 |
+| 기타 실패 | 그 외 거절 사유 | PAYMENT_FAILED | 500 |
+
+### 서킷브레이커 (Resilience4j)
+
+`ExternalPaymentStrategy`에서 외부 결제 클라이언트 호출을 `CircuitBreaker.executeSupplier()`로 감싸 장애 전파를 방지합니다.
+
+**설정값 및 근거**
+
+| 설정 | 값 | 근거 |
+|------|---|------|
+| sliding-window-type | COUNT_BASED | 요청 수 기반이 시간 기반보다 직관적 |
+| sliding-window-size | 10 | 최근 10건 기준으로 판단 |
+| failure-rate-threshold | 50% | 10건 중 5건 실패 시 서킷 오픈 |
+| wait-duration-in-open-state | 10s | 10초 후 반오픈 상태로 전환 |
+| permitted-number-of-calls-in-half-open-state | 3 | 3건 시도하여 복구 여부 판단 |
+| minimum-number-of-calls | 5 | 최소 5건 이후부터 실패율 계산 |
+
+**서킷 OPEN 시 동작**: `CallNotPermittedException` → 외부 호출 없이 즉시 `PAYMENT_TIMEOUT` 반환 → 스레드 점유 방지
+
+**트레이드오프**
+
+- 서킷 오픈 중에는 정상 요청도 즉시 실패하지만, PG 장애 상태에서 어차피 실패할 요청으로 서버 자원을 낭비하는 것보다 나음
+- 재고는 이미 Redis에서 차감된 상태이므로 보상 트랜잭션으로 복구
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Resilience4j
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/reservation/domain/payment/service/strategy/CreditCardPaymentStrategy.java
+++ b/src/main/java/com/reservation/domain/payment/service/strategy/CreditCardPaymentStrategy.java
@@ -2,13 +2,14 @@ package com.reservation.domain.payment.service.strategy;
 
 import com.reservation.domain.payment.client.PgClient;
 import com.reservation.domain.payment.entity.PaymentMethod;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CreditCardPaymentStrategy extends ExternalPaymentStrategy {
 
-    public CreditCardPaymentStrategy(PgClient pgClient) {
-        super(pgClient);
+    public CreditCardPaymentStrategy(PgClient pgClient, CircuitBreakerRegistry registry) {
+        super(pgClient, registry);
     }
 
     @Override

--- a/src/main/java/com/reservation/domain/payment/service/strategy/ExternalPaymentStrategy.java
+++ b/src/main/java/com/reservation/domain/payment/service/strategy/ExternalPaymentStrategy.java
@@ -6,6 +6,7 @@ import com.reservation.domain.payment.client.PaymentResult;
 import com.reservation.domain.payment.entity.Payment;
 import com.reservation.global.exception.GeneralException;
 import com.reservation.global.exception.code.ErrorCode;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 
@@ -24,6 +25,9 @@ public abstract class ExternalPaymentStrategy implements PaymentStrategy {
         PaymentResult result;
         try {
             result = circuitBreaker.executeSupplier(() -> client.pay(payment.getAmount()));
+        } catch (CallNotPermittedException e) {
+            payment.fail();
+            throw new GeneralException(ErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             payment.fail();
             throw new GeneralException(ErrorCode.PAYMENT_TIMEOUT);

--- a/src/main/java/com/reservation/domain/payment/service/strategy/ExternalPaymentStrategy.java
+++ b/src/main/java/com/reservation/domain/payment/service/strategy/ExternalPaymentStrategy.java
@@ -6,18 +6,28 @@ import com.reservation.domain.payment.client.PaymentResult;
 import com.reservation.domain.payment.entity.Payment;
 import com.reservation.global.exception.GeneralException;
 import com.reservation.global.exception.code.ErrorCode;
-import lombok.RequiredArgsConstructor;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 
-@RequiredArgsConstructor
 public abstract class ExternalPaymentStrategy implements PaymentStrategy {
 
     private final ExternalPaymentClient client;
+    private final CircuitBreaker circuitBreaker;
+
+    protected ExternalPaymentStrategy(ExternalPaymentClient client, CircuitBreakerRegistry registry) {
+        this.client = client;
+        this.circuitBreaker = registry.circuitBreaker("externalPayment");
+    }
 
     @Override
     public void pay(Payment payment, Order order) {
         PaymentResult result;
         try {
-            result = client.pay(payment.getAmount());
+            result = circuitBreaker.executeSupplier(() -> client.pay(payment.getAmount()));
+        } catch (CallNotPermittedException e) {
+            payment.fail();
+            throw new GeneralException(ErrorCode.PAYMENT_TIMEOUT);
         } catch (Exception e) {
             payment.fail();
             throw new GeneralException(ErrorCode.PAYMENT_TIMEOUT);

--- a/src/main/java/com/reservation/domain/payment/service/strategy/ExternalPaymentStrategy.java
+++ b/src/main/java/com/reservation/domain/payment/service/strategy/ExternalPaymentStrategy.java
@@ -8,7 +8,6 @@ import com.reservation.global.exception.GeneralException;
 import com.reservation.global.exception.code.ErrorCode;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 
 public abstract class ExternalPaymentStrategy implements PaymentStrategy {
 
@@ -25,9 +24,6 @@ public abstract class ExternalPaymentStrategy implements PaymentStrategy {
         PaymentResult result;
         try {
             result = circuitBreaker.executeSupplier(() -> client.pay(payment.getAmount()));
-        } catch (CallNotPermittedException e) {
-            payment.fail();
-            throw new GeneralException(ErrorCode.PAYMENT_TIMEOUT);
         } catch (Exception e) {
             payment.fail();
             throw new GeneralException(ErrorCode.PAYMENT_TIMEOUT);

--- a/src/main/java/com/reservation/domain/payment/service/strategy/YPayPaymentStrategy.java
+++ b/src/main/java/com/reservation/domain/payment/service/strategy/YPayPaymentStrategy.java
@@ -2,13 +2,14 @@ package com.reservation.domain.payment.service.strategy;
 
 import com.reservation.domain.payment.client.YPayClient;
 import com.reservation.domain.payment.entity.PaymentMethod;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import org.springframework.stereotype.Component;
 
 @Component
 public class YPayPaymentStrategy extends ExternalPaymentStrategy {
 
-    public YPayPaymentStrategy(YPayClient yPayClient) {
-        super(yPayClient);
+    public YPayPaymentStrategy(YPayClient yPayClient, CircuitBreakerRegistry registry) {
+        super(yPayClient, registry);
     }
 
     @Override

--- a/src/main/java/com/reservation/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/reservation/global/exception/code/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     INVALID_PAYMENT_COMBINATION(400, "PAYMENT003", "외부 결제 수단은 하나만 사용할 수 있습니다."),
     PAYMENT_LIMIT_EXCEEDED(400, "PAYMENT004", "결제 한도를 초과했습니다."),
     PAYMENT_TIMEOUT(503, "PAYMENT005", "결제 요청 시간이 초과되었습니다."),
+    PAYMENT_SERVICE_UNAVAILABLE(503, "PAYMENT006", "결제 서비스를 일시적으로 이용할 수 없습니다."),
 
     // Order
     DUPLICATE_ORDER(409, "ORDER001", "이미 처리된 요청입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,17 @@ spring:
   jackson:
     property-naming-strategy: LOWER_CAMEL_CASE
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      externalPayment:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        minimum-number-of-calls: 5
+
 ---
 spring:
   config:


### PR DESCRIPTION
## Summary
- Resilience4j 의존성 추가
- `ExternalPaymentStrategy`: `CircuitBreaker.executeSupplier()`로 외부 결제 호출 보호
- 서킷 OPEN → `PAYMENT_SERVICE_UNAVAILABLE` (503), 타임아웃 → `PAYMENT_TIMEOUT` (503) 분리
- DECISIONS.md 쟁점 6 (결제 실패 케이스별 대응 + 서킷브레이커 설정 근거) 작성

## 서킷브레이커 설정
- 최근 10건 중 50% 실패 → 서킷 OPEN
- 10초 후 HALF-OPEN → 3건 시도 → 성공 시 CLOSED 복귀

## Test plan
- [x] 전체 테스트 통과 확인

closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)