### PR TITLE
feat: Redis 기반 Rate Limiting 구현 (#68)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -131,7 +131,41 @@ public interface PaymentStrategy {
 
 ## 쟁점 3. 멱등성 처리 전략
 
-> Phase 7에서 작성 예정
+> 사용자가 결제 버튼을 빠르게 연속 클릭하거나, 네트워크 오류로 요청이 재전송되는 경우 중복 결제를 방지하는 방법
+
+### 검토한 방식
+
+| 방식 | 핵심 원리 |
+|------|---------|
+| DB UNIQUE 제약조건 | `orders.idempotency_key`에 UNIQUE 제약 |
+| Redis 기반 멱등성 키 | Redis에 키 저장 (TTL 24h), O(1) 조회 |
+| 서버 메모리 캐시 | 서버 내 Map에 키 저장 |
+
+### 최종 선택: Redis 기반 멱등성 키 + DB UNIQUE Fallback
+
+**선택 근거**
+
+- 멱등성 체크는 모든 Booking 요청의 첫 단계이므로 속도가 중요 → Redis O(1) 조회
+- TTL 24시간으로 불필요한 키가 자동 정리됨
+- 분산 환경(서버 2대)에서 동일한 Redis를 바라보므로, 어느 서버로 요청이 들어와도 중복 체크 가능
+- 서버 메모리 캐시는 분산 환경에서 서버 간 공유 불가 → 제외
+
+**Redis 장애 시 Fallback**
+
+- `IdempotencyService.exists()`: Redis 장애 시 DB에서 `idempotency_key`로 기존 주문 존재 여부 확인
+- `IdempotencyService.save()`: Redis 장애 시 저장 생략 — DB UNIQUE 제약조건이 중복 삽입 방지
+- 클라이언트가 `Idempotency-Key` 헤더로 UUID를 전송하는 표준 방식 채택
+
+**처리 흐름**
+
+1. Redis에서 멱등성 키 존재 확인
+2. 존재 → DB에서 기존 주문 조회 후 반환
+3. 미존재 → 예약 플로우 진행 → 성공 시 Redis에 키 저장 (TTL 24h)
+
+**트레이드오프**
+
+- Redis와 DB 양쪽에 멱등성 체크 수단을 두어 단일 장애점 제거
+- TTL 24시간 이후 같은 키로 재요청하면 새 주문이 생성될 수 있으나, 24시간 이후 동일 키 재사용은 실무적으로 발생하지 않는 시나리오
 
 ---
 

--- a/src/main/java/com/reservation/global/config/WebConfig.java
+++ b/src/main/java/com/reservation/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.reservation.global.config;
+
+import com.reservation.global.ratelimit.RateLimitInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor)
+                .addPathPatterns("/api/bookings/**");
+    }
+}

--- a/src/main/java/com/reservation/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/reservation/global/exception/code/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
     NOT_FOUND(404, "COMMON003", "요청한 리소스를 찾을 수 없습니다."),
     VALIDATION_FAILED(400, "COMMON004", "입력값에 대한 검증에 실패했습니다."),
 
+    // Rate Limit
+    RATE_LIMIT_EXCEEDED(429, "COMMON005", "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
+
     // Product
     PRODUCT_NOT_FOUND(404, "PRODUCT001", "상품을 찾을 수 없습니다."),
 

--- a/src/main/java/com/reservation/global/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/reservation/global/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,32 @@
+package com.reservation.global.ratelimit;
+
+import com.reservation.global.common.constants.HeaderConstants;
+import com.reservation.global.exception.GeneralException;
+import com.reservation.global.exception.code.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final RateLimitService rateLimitService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String userIdHeader = request.getHeader(HeaderConstants.USER_ID);
+        if (userIdHeader == null) {
+            return true;
+        }
+
+        Long userId = Long.valueOf(userIdHeader);
+        if (!rateLimitService.isAllowed(userId)) {
+            throw new GeneralException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/reservation/global/ratelimit/RateLimitService.java
+++ b/src/main/java/com/reservation/global/ratelimit/RateLimitService.java
@@ -1,0 +1,37 @@
+package com.reservation.global.ratelimit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RateLimitService {
+
+    private static final String KEY_PREFIX = "ratelimit:user:";
+    private static final int MAX_REQUESTS = 5;
+    private static final Duration WINDOW = Duration.ofSeconds(1);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean isAllowed(Long userId) {
+        try {
+            String key = KEY_PREFIX + userId;
+            Long count = redisTemplate.opsForValue().increment(key);
+
+            if (count == 1L) {
+                redisTemplate.expire(key, WINDOW);
+            }
+
+            return count <= MAX_REQUESTS;
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 장애로 Rate Limiting 비활성화: {}", e.getMessage());
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `RateLimitService`: Redis INCR + EXPIRE로 사용자별 초당 5회 제한
- `RateLimitInterceptor`: `/api/bookings` 경로에 적용
- Redis 장애 시 Rate Limiting 비활성화 (서비스 지속 우선)
- `ErrorCode.RATE_LIMIT_EXCEEDED` (429) 추가

## Test plan
- [x] 전체 테스트 통과 확인

closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)