### PR TITLE
docs: README.md 및 DECISIONS.md 업데이트 (#94)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -42,7 +42,7 @@
 
 **트레이드오프**
 
-- Redis 장애 시 DB 비관적 락으로 Fallback (성능 저하를 감수하되 서비스 중단 방지, Phase 8에서 구현)
+- Redis 장애 시 DB 비관적 락으로 Fallback (성능 저하를 감수하되 서비스 중단 방지, 쟁점 4 참고)
 - Redis는 휘발성이므로 DB를 최종 정합성 기준으로 유지
 - Redis 서버 1대 추가 운영 필요하나, 멱등성 키(Phase 7)·Rate Limiting(Phase 9) 등에서도 활용하므로 비용 대비 효과 충분
 
@@ -280,7 +280,7 @@ Redis가 대부분의 트래픽을 흡수하므로 DB에 도달하는 요청은 
 | permitted-number-of-calls-in-half-open-state | 3 | 3건 시도하여 복구 여부 판단 |
 | minimum-number-of-calls | 5 | 최소 5건 이후부터 실패율 계산 |
 
-**서킷 OPEN 시 동작**: `CallNotPermittedException` → 외부 호출 없이 즉시 `PAYMENT_TIMEOUT` 반환 → 스레드 점유 방지
+**서킷 OPEN 시 동작**: `CallNotPermittedException` → 외부 호출 없이 즉시 `PAYMENT_SERVICE_UNAVAILABLE` 반환 → 스레드 점유 방지
 
 **트레이드오프**
 
@@ -331,4 +331,14 @@ self-invocation 시 Spring AOP 프록시가 동작하지 않는 문제를 방지
 
 ## 쟁점 8. 라이브러리 도입 사유
 
-> 각 라이브러리 도입 시점에 작성 예정
+### Resilience4j
+
+- 외부 결제 연동부에 서킷브레이커 패턴을 적용하기 위해 도입
+- Spring Boot 3과의 통합이 우수하며, Netflix Hystrix의 후속으로 가볍고 모듈화되어 있음
+- `CircuitBreakerRegistry`를 통한 프로그래밍 방식 적용으로 추상 클래스(`ExternalPaymentStrategy`)에서도 유연하게 사용 가능
+
+### Spring Data Redis
+
+- Redis Lua 스크립트 기반 재고 차감, 멱등성 키 저장, Rate Limiting에 활용
+- `StringRedisTemplate`, `RedisScript` 등 Spring 추상화를 통해 Redis 연동을 간결하게 처리
+- Lettuce 기반 비동기 커넥션으로 성능 확보

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | Cache | Redis 7 |
 | Build | Gradle |
 | Infra | Docker Compose (MySQL, Redis) |
-| Library | Spring Data JPA, Spring Data Redis, Resilience4j, Redisson |
+| Library | Spring Data JPA, Spring Data Redis, Resilience4j |
 
 ---
 
@@ -45,6 +45,7 @@ src/main/java/com/reservation/
 │   │   ├── repository/
 │   │   └── service/
 │   └── payment/             # 결제 도메인
+│       ├── client/           # 외부 결제 클라이언트 (PG, Y페이)
 │       ├── dto/
 │       ├── entity/
 │       ├── repository/
@@ -52,12 +53,14 @@ src/main/java/com/reservation/
 │           └── strategy/    # 결제 수단별 Strategy
 └── global/
     ├── common/
+    │   ├── constants/        # 상수 (헤더 등)
     │   ├── dto/              # 공통 응답 포맷
     │   └── entity/           # BaseEntity
-    ├── config/               # Redis, JPA 등 설정
-    └── exception/            # 글로벌 예외 처리
-        ├── code/             # ErrorCode enum
-        └── handler/          # ExceptionHandler
+    ├── config/               # Redis, JPA, Web 설정
+    ├── exception/            # 글로벌 예외 처리
+    │   ├── code/             # ErrorCode enum
+    │   └── handler/          # ExceptionHandler
+    └── ratelimit/            # Rate Limiting
 ```
 
 ---
@@ -152,7 +155,7 @@ Content-Type: application/json
 ```json
 {
   "orderId": 1,
-  "orderNumber": "ORD-20260501-000001",
+  "orderNumber": "ORD-20260501-a3f2b1c4",
   "totalAmount": 50000,
   "orderStatus": "COMPLETED",
   "payments": [
@@ -183,14 +186,18 @@ Content-Type: application/json
 
 | HTTP 상태 | 에러 코드 | 설명 |
 |-----------|----------|------|
-| 400 | `PAYMENT001` | 허용되지 않는 결제 수단 조합 |
-| 400 | `PAYMENT002` | 결제 금액이 상품 가격과 불일치 |
-| 400 | `PAYMENT003` | 결제 승인 실패 (한도 초과 등) |
+| 400 | `PAYMENT002` | 포인트 부족 |
+| 400 | `PAYMENT003` | 외부 결제 수단은 하나만 사용 가능 |
+| 400 | `PAYMENT004` | 결제 한도 초과 |
 | 404 | `PRODUCT001` | 상품을 찾을 수 없음 |
 | 404 | `USER001` | 사용자를 찾을 수 없음 |
-| 409 | `STOCK001` | 재고 부족 |
+| 409 | `STOCK002` | 재고 부족 |
 | 409 | `ORDER001` | 중복 요청 (멱등성 키) |
+| 429 | `COMMON005` | 요청 횟수 초과 (Rate Limiting) |
+| 500 | `PAYMENT001` | 결제 실패 |
 | 500 | `COMMON000` | 서버 내부 오류 |
+| 503 | `PAYMENT005` | 결제 요청 시간 초과 |
+| 503 | `PAYMENT006` | 결제 서비스 일시 이용 불가 (서킷 오픈) |
 
 ---
 


### PR DESCRIPTION
## Summary

### README.md
- 프로젝트 구조에 `client/`, `ratelimit/`, `constants/` 패키지 추가
- 기술 스택에서 Redisson 제거 (미사용)
- 에러 코드 테이블을 실제 ErrorCode enum과 일치시킴
- orderNumber 형식 업데이트 (`ORD-yyyyMMdd-{uuid8}`)

### DECISIONS.md
- 쟁점 1: "Phase 8에서 구현" → "쟁점 4 참고"로 수정
- 쟁점 6: 서킷 OPEN 시 `PAYMENT_SERVICE_UNAVAILABLE`로 수정
- 쟁점 8: 라이브러리 도입 사유 작성 (Resilience4j, Spring Data Redis)

closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)