### PR TITLE
feat: SpringDoc(Swagger) 설정 및 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.springdoc.openapi-gradle-plugin' version '1.9.0'
 }
 
 group = 'com.reservation'
@@ -38,6 +39,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 
+    // SpringDoc OpenAPI (Swagger)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -52,6 +56,11 @@ dependencies {
     testImplementation 'com.redis:testcontainers-redis:2.2.2'
     testImplementation 'org.testcontainers:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+openApi {
+    outputDir = file("$buildDir")
+    outputFileName = 'openapi.json'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/reservation/domain/order/controller/BookingController.java
+++ b/src/main/java/com/reservation/domain/order/controller/BookingController.java
@@ -4,11 +4,16 @@ import com.reservation.domain.order.dto.BookingRequest;
 import com.reservation.domain.order.dto.BookingResponse;
 import com.reservation.domain.order.service.BookingService;
 import com.reservation.global.common.constants.HeaderConstants;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Booking", description = "예약 결제 API")
 @RestController
 @RequestMapping("/api/bookings")
 @RequiredArgsConstructor
@@ -16,10 +21,15 @@ public class BookingController {
 
     private final BookingService bookingService;
 
+    @Operation(summary = "예약 결제", description = "상품을 예약하고 결제를 진행한다. 멱등성 키를 통해 중복 요청을 방지한다.")
+    @ApiResponse(responseCode = "200", description = "예약 결제 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청 (결제 수단 조합 오류, 포인트 부족 등)")
+    @ApiResponse(responseCode = "409", description = "재고 부족 또는 중복 요청")
+    @ApiResponse(responseCode = "503", description = "결제 서비스 일시 불가")
     @PostMapping
     public ResponseEntity<BookingResponse> book(
-            @RequestHeader(HeaderConstants.USER_ID) Long userId,
-            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @Parameter(description = "사용자 ID", required = true) @RequestHeader(HeaderConstants.USER_ID) Long userId,
+            @Parameter(description = "멱등성 키 (중복 요청 방지)", required = true) @RequestHeader("Idempotency-Key") String idempotencyKey,
             @Valid @RequestBody BookingRequest request) {
         BookingResponse response = bookingService.book(userId, idempotencyKey, request);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/reservation/domain/order/controller/CheckoutController.java
+++ b/src/main/java/com/reservation/domain/order/controller/CheckoutController.java
@@ -3,10 +3,15 @@ package com.reservation.domain.order.controller;
 import com.reservation.domain.order.dto.CheckoutResponse;
 import com.reservation.domain.order.service.CheckoutService;
 import com.reservation.global.common.constants.HeaderConstants;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Checkout", description = "체크아웃 API")
 @RestController
 @RequestMapping("/api/checkout")
 @RequiredArgsConstructor
@@ -14,10 +19,13 @@ public class CheckoutController {
 
     private final CheckoutService checkoutService;
 
+    @Operation(summary = "체크아웃 정보 조회", description = "상품 정보, 잔여 재고, 사용자 포인트를 조회한다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "404", description = "상품 또는 사용자를 찾을 수 없음")
     @GetMapping("/products/{productId}")
     public ResponseEntity<CheckoutResponse> checkout(
-            @PathVariable Long productId,
-            @RequestHeader(HeaderConstants.USER_ID) Long userId) {
+            @Parameter(description = "상품 ID") @PathVariable Long productId,
+            @Parameter(description = "사용자 ID", required = true) @RequestHeader(HeaderConstants.USER_ID) Long userId) {
         CheckoutResponse response = checkoutService.getCheckout(productId, userId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/reservation/domain/order/dto/BookingRequest.java
+++ b/src/main/java/com/reservation/domain/order/dto/BookingRequest.java
@@ -1,14 +1,19 @@
 package com.reservation.domain.order.dto;
 
 import com.reservation.domain.payment.dto.PaymentRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
+@Schema(description = "예약 결제 요청")
 public record BookingRequest(
+        @Schema(description = "상품 ID", example = "1")
         @NotNull Long productId,
+
+        @Schema(description = "결제 수단 목록 (포인트 + 외부결제 조합 가능)")
         @NotEmpty @Valid List<PaymentRequest> payments
 ) {
 }

--- a/src/main/java/com/reservation/domain/order/dto/BookingResponse.java
+++ b/src/main/java/com/reservation/domain/order/dto/BookingResponse.java
@@ -4,14 +4,25 @@ import com.reservation.domain.order.entity.Order;
 import com.reservation.domain.order.entity.OrderStatus;
 import com.reservation.domain.payment.dto.PaymentResponse;
 import com.reservation.domain.payment.entity.Payment;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "예약 결제 응답")
 public record BookingResponse(
+        @Schema(description = "주문 ID", example = "1")
         Long orderId,
+
+        @Schema(description = "주문 번호", example = "ORD-20260502-ABC123")
         String orderNumber,
+
+        @Schema(description = "총 결제 금액", example = "100000")
         int totalAmount,
+
+        @Schema(description = "주문 상태", example = "COMPLETED")
         OrderStatus orderStatus,
+
+        @Schema(description = "결제 내역 목록")
         List<PaymentResponse> payments
 ) {
     public static BookingResponse of(Order order, List<Payment> payments) {

--- a/src/main/java/com/reservation/domain/order/dto/CheckoutResponse.java
+++ b/src/main/java/com/reservation/domain/order/dto/CheckoutResponse.java
@@ -3,17 +3,34 @@ package com.reservation.domain.order.dto;
 import com.reservation.domain.product.entity.Product;
 import com.reservation.domain.stock.entity.Stock;
 import com.reservation.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalTime;
 
+@Schema(description = "체크아웃 정보 응답")
 public record CheckoutResponse(
+        @Schema(description = "상품 ID", example = "1")
         Long productId,
+
+        @Schema(description = "상품명", example = "디럭스 더블룸")
         String productName,
+
+        @Schema(description = "가격", example = "100000")
         int price,
+
+        @Schema(description = "체크인 시간", example = "15:00:00")
         LocalTime checkInTime,
+
+        @Schema(description = "체크아웃 시간", example = "11:00:00")
         LocalTime checkOutTime,
+
+        @Schema(description = "상품 설명", example = "오션뷰 디럭스 더블룸")
         String description,
+
+        @Schema(description = "잔여 재고 수량", example = "5")
         int remainingStock,
+
+        @Schema(description = "사용자 보유 포인트", example = "50000")
         int userPoint
 ) {
 

--- a/src/main/java/com/reservation/domain/payment/dto/PaymentRequest.java
+++ b/src/main/java/com/reservation/domain/payment/dto/PaymentRequest.java
@@ -1,11 +1,16 @@
 package com.reservation.domain.payment.dto;
 
 import com.reservation.domain.payment.entity.PaymentMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "결제 수단 요청")
 public record PaymentRequest(
+        @Schema(description = "결제 수단", example = "CREDIT_CARD")
         @NotNull PaymentMethod method,
+
+        @Schema(description = "결제 금액", example = "50000")
         @Positive int amount
 ) {
 }

--- a/src/main/java/com/reservation/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/reservation/domain/payment/dto/PaymentResponse.java
@@ -3,10 +3,17 @@ package com.reservation.domain.payment.dto;
 import com.reservation.domain.payment.entity.Payment;
 import com.reservation.domain.payment.entity.PaymentMethod;
 import com.reservation.domain.payment.entity.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "결제 결과 응답")
 public record PaymentResponse(
+        @Schema(description = "결제 수단", example = "CREDIT_CARD")
         PaymentMethod method,
+
+        @Schema(description = "결제 금액", example = "50000")
         int amount,
+
+        @Schema(description = "결제 상태", example = "SUCCESS")
         PaymentStatus status
 ) {
     public static PaymentResponse from(Payment payment) {

--- a/src/main/java/com/reservation/global/config/SwaggerConfig.java
+++ b/src/main/java/com/reservation/global/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.reservation.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Reservation Payment Platform API")
+                        .version("v1.0.0")
+                        .description("선착순 예약 결제 플랫폼 API 문서"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,14 @@ spring:
   jackson:
     property-naming-strategy: LOWER_CAMEL_CASE
 
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
+
 resilience4j:
   circuitbreaker:
     instances:


### PR DESCRIPTION
## Summary
- SpringDoc OpenAPI(Swagger UI) 도입 및 전체 API 문서화
- Controller에 `@Tag`, `@Operation`, `@ApiResponse` 어���테이션 추가
- DTO에 `@Schema` 어노���이션으로 필드 설명 및 예시값 추가
- `openapi-gradle-plugin` 추가로 CI에서 OpenAPI JSON 자동 생성 가능

## Changes
- `build.gradle`: springdoc-openapi 의존성 + gradle plugin 추가
- `SwaggerConfig.java`: OpenAPI 메타 정보 설정
- `CheckoutController`, `BookingController`: Swagger 어노테이션
- `BookingRequest`, `BookingResponse`, `CheckoutResponse`, `PaymentRequest`, `PaymentResponse`: @Schema 어노테이션
- `application.yml`: springdoc 경로 설정

## Test plan
- [x] `./gradlew compileJava` 빌드 성공
- [ ] 앱 실행 후 `/swagger-ui.html` 접속하여 문서 확인

Closes #96