### PR TITLE
feat: GitHub Actions CI/CD 파이프라인 구축 (GHCR + API Docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: reservation
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Run tests
+        run: ./gradlew test
+        env:
+          SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/reservation?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+          SPRING_DATASOURCE_USERNAME: root
+          SPRING_DATASOURCE_PASSWORD: root
+          SPRING_DATA_REDIS_HOST: localhost
+          SPRING_DATA_REDIS_PORT: 6379

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,106 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+
+    env:
+      REGISTRY: ghcr.io
+      REPOSITORY: ${{ github.repository }}
+      IMAGE_TAG: latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Resolve build version
+        id: vars
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v6
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
+          platforms: linux/amd64
+
+  docs:
+    name: Deploy API Docs
+    runs-on: ubuntu-latest
+    needs: deploy
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Generate OpenAPI (offline)
+        run: ./gradlew clean generateOpenApiDocs
+
+      - name: Sort OpenAPI tags by name
+        run: |
+          jq '.tags |= sort_by(.name)' build/openapi.json > build/openapi_sorted.json
+          mv build/openapi_sorted.json build/openapi.json
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Redoc CLI
+        run: npm i -g redoc-cli
+
+      - name: Build Redoc (HTML)
+        run: |
+          mkdir -p public
+          redoc-cli bundle build/openapi.json -o public/index.html
+
+      - name: Upload artifact for Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- **CI**: PR → main 시 테스트 실행, 통과해야만 머지 가능
- **CD**: main push 시 Docker 이미지 GHCR 푸시 + API Docs GitHub Pages 배포

## Changes
- `.github/workflows/ci.yml`: PR 테스트 자동화 (MySQL + Redis 서비스 컨테이너)
- `.github/workflows/deploy.yml`: Docker 빌드/푸시 + Redoc API Docs 배포

## 워크플로우 구성
### CI (ci.yml)
- Trigger: PR to main
- MySQL 8.0 + Redis 7 서비스 컨테이너
- `./gradlew test` 실행

### CD (deploy.yml)
- Trigger: push to main
- **deploy job**: Docker Buildx → GHCR 이미지 푸시 (latest + git tag)
- **docs job**: Gradle OpenAPI 생성 → Redoc HTML → GitHub Pages 배포

## Test plan
- [ ] PR 생성 시 CI 워크플로우 실행 확인
- [ ] 테스트 실패 시 머지 차단 확인
- [ ] main push 시 GHCR 이미지 업로드 확인
- [ ] GitHub Pages API 문서 배포 확인

Closes #99