### PR TITLE
feat: docker-compose.yml 운영 환경 구성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,24 @@
 services:
+  server:
+    container_name: reservation-server
+    image: ${IMAGE:-ghcr.io/hyunmin0317/reservation-payment-platform:latest}
+    environment:
+      TZ: Asia/Seoul
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILE:-local}
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/reservation?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+    ports:
+      - "8080:8080"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: always
+
   mysql:
     image: mysql:8.0
     container_name: reservation-mysql
@@ -14,6 +34,11 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7
@@ -22,6 +47,11 @@ services:
       - "6379:6379"
     volumes:
       - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   mysql-data:


### PR DESCRIPTION
## Summary
- docker-compose.yml에 GHCR 이미지 기반 서버 컨테이너 추가
- MySQL/Redis healthcheck로 의존성 순서 보장

## Changes
- `docker-compose.yml`: server 서비스 추가, healthcheck 및 depends_on 설정

## Test plan
- [ ] `docker compose up -d`로 전체 스택 기동 확인
- [ ] 서버가 MySQL/Redis 준비 후 정상 시작되는지 확인

Closes #100