### PR TITLE
fix: GHCR 인증을 GITHUB_TOKEN으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve build version
         id: vars


### PR DESCRIPTION
## Summary
- deploy.yml GHCR 로그인 시 `GHCR_TOKEN` → `GITHUB_TOKEN`으로 변경
- 별도 PAT 시크릿 등록 없이 GHCR 푸시 가능

## Changes
- `.github/workflows/deploy.yml`: password 변경

Closes #107