### PR TITLE
feat: API Docs 생성용 docs 프로필 및 테스트 설정 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
 
     // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -61,6 +62,9 @@ dependencies {
 openApi {
     outputDir = file("$buildDir")
     outputFileName = 'openapi.json'
+    customBootRun {
+        args = ["--spring.profiles.active=docs"]
+    }
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,25 @@ spring:
 
 server:
   port: 8080
+
+---
+spring:
+  config:
+    activate:
+      on-profile: docs
+
+  datasource:
+    url: jdbc:h2:mem:docs
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/test/java/com/reservation/support/IntegrationTestSupport.java
+++ b/src/test/java/com/reservation/support/IntegrationTestSupport.java
@@ -2,14 +2,12 @@ package com.reservation.support;
 
 import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest
-@ActiveProfiles("test")
 public abstract class IntegrationTestSupport {
 
     static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,4 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
## Summary
- docs 프로필 추가로 CI에서 MySQL/Redis 없이 OpenAPI JSON 생성 가능
- 테스트 설정 파일 컨벤션 개선

## Changes
- `application.yml`: docs 프로필 추가 (H2 인메모리 DB)
- `build.gradle`: H2 의존성 추가, openApi에 docs 프로필 적용
- `application-test.yml` → `application.yml` 이동 (Spring Boot 컨벤션)
- `IntegrationTestSupport`: `@ActiveProfiles("test")` 제거 (불필요)

## Test plan
- [x] `./gradlew compileJava compileTestJava` 빌드 성공
- [x] `./gradlew generateOpenApiDocs` 로컬 실행 성공 (MySQL/Redis 불필요)

Closes #111