### PR TITLE
v0.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,30 +13,6 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: reservation
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -h localhost"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,9 +26,3 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
-        env:
-          SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/reservation?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
-          SPRING_DATASOURCE_USERNAME: root
-          SPRING_DATASOURCE_PASSWORD: root
-          SPRING_DATA_REDIS_HOST: localhost
-          SPRING_DATA_REDIS_PORT: 6379

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
 
     // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -61,6 +62,9 @@ dependencies {
 openApi {
     outputDir = file("$buildDir")
     outputFileName = 'openapi.json'
+    customBootRun {
+        args = ["--spring.profiles.active=docs"]
+    }
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,25 @@ spring:
 
 server:
   port: 8080
+
+---
+spring:
+  config:
+    activate:
+      on-profile: docs
+
+  datasource:
+    url: jdbc:h2:mem:docs
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/test/java/com/reservation/support/IntegrationTestSupport.java
+++ b/src/test/java/com/reservation/support/IntegrationTestSupport.java
@@ -2,14 +2,12 @@ package com.reservation.support;
 
 import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest
-@ActiveProfiles("test")
 public abstract class IntegrationTestSupport {
 
     static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,4 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
## Summary
- GHCR 인증 GITHUB_TOKEN 적용 (#107)
- API Docs 생성용 docs 프로필 추가 (#111)
- 테스트 설정 파일 컨벤션 개선

## Changes
- `deploy.yml`: GHCR_TOKEN → GITHUB_TOKEN
- `application.yml`: docs 프로필 (H2 인메모리), test 프로필 통합
- `build.gradle`: H2 의존성, openApi docs 프로필 적용
- 테스트 설정 파일 리네임 및 @ActiveProfiles 제거