### PR TITLE
fix: CircuitBreakerTest flaky 테스트 수정

### DIFF
--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -62,7 +62,9 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         productRepository.deleteAll();
         userRepository.deleteAll();
 
-        circuitBreakerRegistry.circuitBreaker("externalPayment").reset();
+        CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("externalPayment");
+        cb.transitionToClosedState();
+        cb.reset();
 
         User user = userRepository.saveAndFlush(User.create("테스트유저", "test@test.com", 50000));
         Product product = productRepository.saveAndFlush(Product.create(
@@ -124,6 +126,9 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         when(pgClient.pay(anyInt())).thenThrow(new RuntimeException("PG down"));
 
         CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("externalPayment");
+        cb.transitionToClosedState();
+        cb.reset();
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
         for (int i = 0; i < 10; i++) {
             try {


### PR DESCRIPTION
## Summary
- 서킷브레이커 테스트에서 상태 오염으로 인한 간헐적 실패 수정

## Changes
- `CircuitBreakerTest.java`: `@BeforeEach`에서 CB를 CLOSED로 명시적 전환 후 reset, 테스트 시작 전 상태 검증 추가

## Test plan
- [x] `./gradlew compileTestJava` 빌드 성공
- [ ] CI에서 안정적으로 통과 확인

Closes #114