### PR TITLE
v0.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,30 +13,6 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: reservation
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -h localhost"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,9 +26,3 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
-        env:
-          SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/reservation?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
-          SPRING_DATASOURCE_USERNAME: root
-          SPRING_DATASOURCE_PASSWORD: root
-          SPRING_DATA_REDIS_HOST: localhost
-          SPRING_DATA_REDIS_PORT: 6379

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
 
     // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -61,6 +62,9 @@ dependencies {
 openApi {
     outputDir = file("$buildDir")
     outputFileName = 'openapi.json'
+    customBootRun {
+        args = ["--spring.profiles.active=docs"]
+    }
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,25 @@ spring:
 
 server:
   port: 8080
+
+---
+spring:
+  config:
+    activate:
+      on-profile: docs
+
+  datasource:
+    url: jdbc:h2:mem:docs
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CircuitBreakerTest extends IntegrationTestSupport {
 
     @Autowired
@@ -62,9 +64,10 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         productRepository.deleteAll();
         userRepository.deleteAll();
 
-        CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("externalPayment");
-        cb.transitionToClosedState();
-        cb.reset();
+        circuitBreakerRegistry.getAllCircuitBreakers().forEach(cb -> {
+            cb.transitionToClosedState();
+            cb.reset();
+        });
 
         User user = userRepository.saveAndFlush(User.create("테스트유저", "test@test.com", 50000));
         Product product = productRepository.saveAndFlush(Product.create(
@@ -126,8 +129,6 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         when(pgClient.pay(anyInt())).thenThrow(new RuntimeException("PG down"));
 
         CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("externalPayment");
-        cb.transitionToClosedState();
-        cb.reset();
         assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
         for (int i = 0; i < 10; i++) {

--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -62,7 +62,9 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         productRepository.deleteAll();
         userRepository.deleteAll();
 
-        circuitBreakerRegistry.circuitBreaker("externalPayment").reset();
+        CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("externalPayment");
+        cb.transitionToClosedState();
+        cb.reset();
 
         User user = userRepository.saveAndFlush(User.create("테스트유저", "test@test.com", 50000));
         Product product = productRepository.saveAndFlush(Product.create(
@@ -124,6 +126,9 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         when(pgClient.pay(anyInt())).thenThrow(new RuntimeException("PG down"));
 
         CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("externalPayment");
+        cb.transitionToClosedState();
+        cb.reset();
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
         for (int i = 0; i < 10; i++) {
             try {

--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 class CircuitBreakerTest extends IntegrationTestSupport {
 
     @Autowired
@@ -131,15 +131,21 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("externalPayment");
         assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
+        int failureCount = 0;
         for (int i = 0; i < 10; i++) {
             try {
                 paymentService.pay(order, List.of(
                         new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
                 ));
-            } catch (GeneralException ignored) {
+            } catch (GeneralException e) {
+                failureCount++;
+                if (cb.getState() == CircuitBreaker.State.OPEN) {
+                    break;
+                }
             }
         }
 
+        assertThat(failureCount).isGreaterThanOrEqualTo(5);
         assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
 
         assertThatThrownBy(() -> paymentService.pay(order, List.of(

--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -131,25 +131,15 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("externalPayment");
         assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
-        int failureCount = 0;
         for (int i = 0; i < 10; i++) {
             try {
                 paymentService.pay(order, List.of(
                         new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
                 ));
-            } catch (GeneralException e) {
-                failureCount++;
-                System.out.println("[CB-TEST] iteration=" + i + " errorCode=" + e.getErrorCode() + " cbState=" + cb.getState() + " metrics=" + cb.getMetrics().getNumberOfFailedCalls());
-                if (cb.getState() == CircuitBreaker.State.OPEN) {
-                    break;
-                }
-            } catch (Exception e) {
-                System.out.println("[CB-TEST] iteration=" + i + " unexpected=" + e.getClass().getName() + " msg=" + e.getMessage());
+            } catch (GeneralException ignored) {
             }
         }
 
-        System.out.println("[CB-TEST] final failureCount=" + failureCount + " cbState=" + cb.getState() + " metrics=" + cb.getMetrics().getNumberOfFailedCalls());
-        assertThat(failureCount).isGreaterThanOrEqualTo(5);
         assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
 
         assertThatThrownBy(() -> paymentService.pay(order, List.of(

--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -139,12 +139,16 @@ class CircuitBreakerTest extends IntegrationTestSupport {
                 ));
             } catch (GeneralException e) {
                 failureCount++;
+                System.out.println("[CB-TEST] iteration=" + i + " errorCode=" + e.getErrorCode() + " cbState=" + cb.getState() + " metrics=" + cb.getMetrics().getNumberOfFailedCalls());
                 if (cb.getState() == CircuitBreaker.State.OPEN) {
                     break;
                 }
+            } catch (Exception e) {
+                System.out.println("[CB-TEST] iteration=" + i + " unexpected=" + e.getClass().getName() + " msg=" + e.getMessage());
             }
         }
 
+        System.out.println("[CB-TEST] final failureCount=" + failureCount + " cbState=" + cb.getState() + " metrics=" + cb.getMetrics().getNumberOfFailedCalls());
         assertThat(failureCount).isGreaterThanOrEqualTo(5);
         assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
 

--- a/src/test/java/com/reservation/support/IntegrationTestSupport.java
+++ b/src/test/java/com/reservation/support/IntegrationTestSupport.java
@@ -2,14 +2,12 @@ package com.reservation.support;
 
 import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest
-@ActiveProfiles("test")
 public abstract class IntegrationTestSupport {
 
     static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,6 +3,18 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: false
+    open-in-view: false
     properties:
       hibernate:
         format_sql: false
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      externalPayment:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        minimum-number-of-calls: 5

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,4 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
## Summary
- CircuitBreakerTest flaky 테스트 수정 (#114)
- 테스트 application.yml에 resilience4j 설정 누락 문제 해결

## Root Cause
`src/test/resources/application.yml`이 `src/main/resources/application.yml`을 완전히 대체하여 resilience4j 설정이 누락됨. CB threshold가 없어 서킷이 OPEN되지 않았음.