### PR TITLE
refactor: docker-compose 환경변수 중복 제거 및 docker 프로필 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,28 +67,14 @@ src/main/java/com/reservation/
 
 ## 실행 방법
 
-### 1. 사전 요구사항
-- Java 17+
+### 사전 요구사항
 - Docker, Docker Compose
 
-### 2. 인프라 실행
+### 실행
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
-
-### 3. 애플리케이션 실행
-```bash
-./gradlew bootRun
-```
-
-### 4. 분산 환경 테스트 (2대 서버)
-```bash
-# 서버 1 (8080 포트)
-./gradlew bootRun --args='--server.port=8080'
-
-# 서버 2 (8081 포트)
-./gradlew bootRun --args='--server.port=8081'
-```
+> 애플리케이션(Spring Boot) + MySQL + Redis가 모두 실행됩니다.
 
 ---
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,20 +1,4 @@
 services:
-  server:
-    container_name: reservation-server
-    build: .
-    image: ghcr.io/hyunmin0317/reservation-payment-platform:latest
-    environment:
-      TZ: Asia/Seoul
-      SPRING_PROFILES_ACTIVE: docker
-    ports:
-      - "8080:8080"
-    depends_on:
-      mysql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    restart: always
-
   mysql:
     image: mysql:8.0
     container_name: reservation-mysql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,26 @@ server:
 spring:
   config:
     activate:
+      on-profile: docker
+
+  datasource:
+    url: jdbc:mysql://mysql:3306/reservation?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show-sql: false
+
+  data:
+    redis:
+      host: redis
+      port: 6379
+
+---
+spring:
+  config:
+    activate:
       on-profile: docs
 
   datasource:


### PR DESCRIPTION
## Summary
- docker-compose.yml에서 Spring 환경변수 중복 제거, `SPRING_PROFILES_ACTIVE: docker`만 유지
- application.yml에 `docker` 프로필 추가 (host: mysql, redis)
- `build: .` 추가로 로컬에서 `docker compose up -d`로 바로 실행 가능
- 로컬 개발용 `docker-compose.local.yml` 분리 (MySQL + Redis만)
- README.md 실행 방법 간소화

close #126

## Test plan
- [x] `docker compose up -d`로 전체 실행 확인
- [x] `docker compose -f docker-compose.local.yml up -d`로 인프라만 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)