### PR TITLE
feat: docker-compose 분산 환경 구성 (서버 2대 + Nginx 로드밸런서)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN ./gradlew build -x test --no-daemon
 
 FROM eclipse-temurin:17-jre-jammy
 
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/build/libs/*.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | Database | MySQL 8.0 |
 | Cache | Redis 7 |
 | Build | Gradle |
-| Infra | Docker Compose (MySQL, Redis) |
+| Infra | Docker Compose (Nginx, MySQL, Redis) |
 | Library | Spring Data JPA, Spring Data Redis, Resilience4j |
 
 ---
@@ -197,14 +197,14 @@ Content-Type: application/json
      └───────┬───────┘
              │
      ┌───────▼───────┐
-     │  Load Balancer │
+     │  Nginx (:80)  │
      └───────┬───────┘
              │
      ┌───────┴───────┐
      │               │
 ┌────▼────┐    ┌────▼────┐
-│ Server 1│    │ Server 2│
-│ (:8080) │    │ (:8081) │
+│Server 1 │    │Server 2 │
+│ (:8080) │    │ (:8080) │
 └────┬────┘    └────┬────┘
      │               │
      └───────┬───────┘

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     // Resilience4j
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,56 @@
 services:
-  server:
-    container_name: reservation-server
+  nginx:
+    image: nginx:latest
+    container_name: reservation-nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./infra/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      server-1:
+        condition: service_healthy
+      server-2:
+        condition: service_healthy
+    restart: always
+
+  server-1:
+    container_name: reservation-server-1
     build: .
     image: ghcr.io/hyunmin0317/reservation-payment-platform:latest
     environment:
       TZ: Asia/Seoul
       SPRING_PROFILES_ACTIVE: docker
-    ports:
-      - "8080:8080"
     depends_on:
       mysql:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: always
+
+  server-2:
+    container_name: reservation-server-2
+    build: .
+    image: ghcr.io/hyunmin0317/reservation-payment-platform:latest
+    environment:
+      TZ: Asia/Seoul
+      SPRING_PROFILES_ACTIVE: docker
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: always
 
   mysql:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,15 @@
+upstream app {
+    server server-1:8080;
+    server server-2:8080;
+}
+
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
## Summary
- docker-compose.yml에 서버 2대(server-1, server-2) 구성
- Nginx 로드밸런서 추가 (라운드로빈, `infra/nginx/nginx.conf`)
- `spring-boot-starter-actuator` 추가 (컨테이너 healthcheck용)
- Dockerfile에 curl 설치 (healthcheck용)
- README.md 시스템 아키텍처 업데이트 (Nginx 반영)

close #128

## Test plan
- [x] `docker compose up -d --build`로 전체 실행 확인
- [x] 5개 컨테이너 모두 healthy 상태 확인
- [x] Nginx(:80) 통해 actuator/health 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)