### PR TITLE
fix: 결제 금액 합계 검증 추가 (#131)

### DIFF
--- a/src/main/java/com/reservation/domain/order/service/OrderTransactionService.java
+++ b/src/main/java/com/reservation/domain/order/service/OrderTransactionService.java
@@ -34,7 +34,7 @@ public class OrderTransactionService {
                 .build();
         orderRepository.save(order);
 
-        List<Payment> payments = paymentService.pay(order, request.payments());
+        List<Payment> payments = paymentService.pay(order, request.payments(), product.getPrice());
 
         if (decreaseDbStock) {
             stockService.decreaseWithPessimisticLock(product.getId());

--- a/src/main/java/com/reservation/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/domain/payment/service/PaymentService.java
@@ -32,7 +32,8 @@ public class PaymentService {
     }
 
     @Transactional
-    public List<Payment> pay(Order order, List<PaymentRequest> requests) {
+    public List<Payment> pay(Order order, List<PaymentRequest> requests, int productPrice) {
+        validateTotalAmount(requests, productPrice);
         validateCombination(requests);
 
         List<PaymentRequest> sorted = sortInternalFirst(requests);
@@ -58,6 +59,13 @@ public class PaymentService {
         }
 
         return completedPayments;
+    }
+
+    private void validateTotalAmount(List<PaymentRequest> requests, int productPrice) {
+        int totalPayment = requests.stream().mapToInt(PaymentRequest::amount).sum();
+        if (totalPayment != productPrice) {
+            throw new GeneralException(ErrorCode.INVALID_PAYMENT_AMOUNT);
+        }
     }
 
     private void validateCombination(List<PaymentRequest> requests) {

--- a/src/main/java/com/reservation/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/reservation/global/exception/code/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     PAYMENT_LIMIT_EXCEEDED(400, "PAYMENT004", "결제 한도를 초과했습니다."),
     PAYMENT_TIMEOUT(503, "PAYMENT005", "결제 요청 시간이 초과되었습니다."),
     PAYMENT_SERVICE_UNAVAILABLE(503, "PAYMENT006", "결제 서비스를 일시적으로 이용할 수 없습니다."),
+    INVALID_PAYMENT_AMOUNT(400, "PAYMENT007", "결제 금액 합계가 상품 가격과 일치하지 않습니다."),
 
     // Order
     DUPLICATE_ORDER(409, "ORDER001", "이미 처리된 요청입니다."),

--- a/src/test/java/com/reservation/domain/order/service/BookingPaymentFlowTest.java
+++ b/src/test/java/com/reservation/domain/order/service/BookingPaymentFlowTest.java
@@ -140,7 +140,7 @@ class BookingPaymentFlowTest extends IntegrationTestSupport {
         @DisplayName("포인트 부족 시 예약 실패")
         @Test
         void insufficientPointsFails() {
-            assertThatThrownBy(() -> book(PaymentMethod.Y_POINT, 60000))
+            assertThatThrownBy(() -> book(PaymentMethod.Y_POINT, 100000))
                     .isInstanceOf(GeneralException.class)
                     .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
                             .isEqualTo(ErrorCode.INSUFFICIENT_POINTS));

--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -86,7 +86,7 @@ class CircuitBreakerTest extends IntegrationTestSupport {
 
         assertThatThrownBy(() -> paymentService.pay(order, List.of(
                 new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
-        )))
+        ), 100000))
                 .isInstanceOf(GeneralException.class)
                 .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
                         .isEqualTo(ErrorCode.PAYMENT_FAILED));
@@ -99,7 +99,7 @@ class CircuitBreakerTest extends IntegrationTestSupport {
 
         assertThatThrownBy(() -> paymentService.pay(order, List.of(
                 new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
-        )))
+        ), 100000))
                 .isInstanceOf(GeneralException.class)
                 .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
                         .isEqualTo(ErrorCode.PAYMENT_LIMIT_EXCEEDED));
@@ -112,7 +112,7 @@ class CircuitBreakerTest extends IntegrationTestSupport {
 
         assertThatThrownBy(() -> paymentService.pay(order, List.of(
                 new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
-        )))
+        ), 100000))
                 .isInstanceOf(GeneralException.class)
                 .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
                         .isEqualTo(ErrorCode.PAYMENT_TIMEOUT));
@@ -129,7 +129,7 @@ class CircuitBreakerTest extends IntegrationTestSupport {
             try {
                 paymentService.pay(order, List.of(
                         new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
-                ));
+                ), 100000);
             } catch (GeneralException ignored) {
             }
         }
@@ -138,7 +138,7 @@ class CircuitBreakerTest extends IntegrationTestSupport {
 
         assertThatThrownBy(() -> paymentService.pay(order, List.of(
                 new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
-        )))
+        ), 100000))
                 .isInstanceOf(GeneralException.class)
                 .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
                         .isEqualTo(ErrorCode.PAYMENT_SERVICE_UNAVAILABLE));

--- a/src/test/java/com/reservation/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/PaymentServiceTest.java
@@ -70,6 +70,21 @@ class PaymentServiceTest extends IntegrationTestSupport {
                 .build());
     }
 
+    private Order createOrderWithAmount(int amount) {
+        Product product = productRepository.saveAndFlush(Product.create(
+                "테스트 숙소", amount,
+                LocalTime.of(15, 0), LocalTime.of(11, 0),
+                "결제 테스트용 상품"
+        ));
+        return orderRepository.saveAndFlush(Order.builder()
+                .orderNumber("ORD-TEST-" + System.nanoTime())
+                .user(user)
+                .product(product)
+                .totalAmount(amount)
+                .idempotencyKey("test-key-" + System.nanoTime())
+                .build());
+    }
+
     @Nested
     @DisplayName("단일 결제")
     class SinglePayment {
@@ -78,7 +93,7 @@ class PaymentServiceTest extends IntegrationTestSupport {
         @Test
         void creditCardPaymentSucceeds() {
             List<Payment> payments = paymentService.pay(order,
-                    List.of(new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)));
+                    List.of(new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)), 100000);
 
             assertThat(payments).hasSize(1);
             assertThat(payments.get(0).getStatus()).isEqualTo(PaymentStatus.APPROVED);
@@ -89,7 +104,7 @@ class PaymentServiceTest extends IntegrationTestSupport {
         @Test
         void yPayPaymentSucceeds() {
             List<Payment> payments = paymentService.pay(order,
-                    List.of(new PaymentRequest(PaymentMethod.Y_PAY, 100000)));
+                    List.of(new PaymentRequest(PaymentMethod.Y_PAY, 100000)), 100000);
 
             assertThat(payments).hasSize(1);
             assertThat(payments.get(0).getStatus()).isEqualTo(PaymentStatus.APPROVED);
@@ -98,20 +113,22 @@ class PaymentServiceTest extends IntegrationTestSupport {
         @DisplayName("Y포인트 결제 성공 시 잔액 차감")
         @Test
         void yPointPaymentSucceeds() {
-            List<Payment> payments = paymentService.pay(order,
-                    List.of(new PaymentRequest(PaymentMethod.Y_POINT, 30000)));
+            Order pointOrder = createOrderWithAmount(50000);
+
+            List<Payment> payments = paymentService.pay(pointOrder,
+                    List.of(new PaymentRequest(PaymentMethod.Y_POINT, 50000)), 50000);
 
             assertThat(payments).hasSize(1);
             assertThat(payments.get(0).getStatus()).isEqualTo(PaymentStatus.APPROVED);
             User updatedUser = userRepository.findById(user.getId()).orElseThrow();
-            assertThat(updatedUser.getPointBalance()).isEqualTo(20000);
+            assertThat(updatedUser.getPointBalance()).isEqualTo(0);
         }
 
         @DisplayName("Y포인트 잔액 부족 시 결제 실패")
         @Test
         void yPointPaymentFailsWhenInsufficientBalance() {
             assertThatThrownBy(() -> paymentService.pay(order,
-                    List.of(new PaymentRequest(PaymentMethod.Y_POINT, 60000))))
+                    List.of(new PaymentRequest(PaymentMethod.Y_POINT, 100000)), 100000))
                     .isInstanceOf(GeneralException.class)
                     .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
                             .isEqualTo(ErrorCode.INSUFFICIENT_POINTS));
@@ -128,7 +145,7 @@ class PaymentServiceTest extends IntegrationTestSupport {
             List<Payment> payments = paymentService.pay(order, List.of(
                     new PaymentRequest(PaymentMethod.Y_POINT, 30000),
                     new PaymentRequest(PaymentMethod.CREDIT_CARD, 70000)
-            ));
+            ), 100000);
 
             assertThat(payments).hasSize(2);
             assertThat(payments).allMatch(p -> p.getStatus() == PaymentStatus.APPROVED);
@@ -142,12 +159,28 @@ class PaymentServiceTest extends IntegrationTestSupport {
             List<Payment> payments = paymentService.pay(order, List.of(
                     new PaymentRequest(PaymentMethod.Y_POINT, 20000),
                     new PaymentRequest(PaymentMethod.Y_PAY, 80000)
-            ));
+            ), 100000);
 
             assertThat(payments).hasSize(2);
             assertThat(payments).allMatch(p -> p.getStatus() == PaymentStatus.APPROVED);
             User updatedUser = userRepository.findById(user.getId()).orElseThrow();
             assertThat(updatedUser.getPointBalance()).isEqualTo(30000);
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 금액 검증")
+    class PaymentAmountValidation {
+
+        @DisplayName("결제 금액 합계가 상품 가격과 다르면 실패")
+        @Test
+        void failsWhenTotalAmountMismatch() {
+            assertThatThrownBy(() -> paymentService.pay(order, List.of(
+                    new PaymentRequest(PaymentMethod.CREDIT_CARD, 50000)
+            ), 100000))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_PAYMENT_AMOUNT));
         }
     }
 
@@ -161,7 +194,7 @@ class PaymentServiceTest extends IntegrationTestSupport {
             assertThatThrownBy(() -> paymentService.pay(order, List.of(
                     new PaymentRequest(PaymentMethod.CREDIT_CARD, 50000),
                     new PaymentRequest(PaymentMethod.Y_PAY, 50000)
-            )))
+            ), 100000))
                     .isInstanceOf(GeneralException.class)
                     .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_PAYMENT_COMBINATION));
@@ -175,7 +208,7 @@ class PaymentServiceTest extends IntegrationTestSupport {
             List<Payment> payments = paymentService.pay(order, List.of(
                     new PaymentRequest(PaymentMethod.Y_POINT, 10000),
                     new PaymentRequest(PaymentMethod.CREDIT_CARD, 90000)
-            ));
+            ), 100000);
 
             assertThat(payments).hasSize(2);
             User updatedUser = userRepository.findById(user.getId()).orElseThrow();


### PR DESCRIPTION
## Summary
- `PaymentService.pay()`에 결제 금액 합계 = 상품 가격 검증 로직 추가
- `ErrorCode.INVALID_PAYMENT_AMOUNT` 추가
- 기존 테스트 금액 정합성 맞춤 및 금액 불일치 테스트 추가

closes #131