### PR TITLE
fix: 멱등성 키 SETNX 선점 방식으로 변경 (#132)

### DIFF
--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -32,7 +32,7 @@ public class BookingService {
     private final IdempotencyService idempotencyService;
 
     public BookingResponse book(Long userId, String idempotencyKey, BookingRequest request) {
-        if (idempotencyService.exists(idempotencyKey)) {
+        if (!idempotencyService.tryAcquire(idempotencyKey)) {
             return getExistingOrder(idempotencyKey);
         }
 
@@ -43,12 +43,12 @@ public class BookingService {
 
         try {
             OrderResult result = orderTransactionService.process(user, product, idempotencyKey, request, redisUsed);
-            idempotencyService.save(idempotencyKey);
             return BookingResponse.of(result.order(), result.payments());
         } catch (Exception e) {
             if (redisUsed) {
                 redisStockService.increase(product.getId());
             }
+            idempotencyService.release(idempotencyKey);
             orderTransactionService.markFailed(idempotencyKey);
             throw e;
         }

--- a/src/main/java/com/reservation/domain/order/service/IdempotencyService.java
+++ b/src/main/java/com/reservation/domain/order/service/IdempotencyService.java
@@ -20,20 +20,22 @@ public class IdempotencyService {
     private final StringRedisTemplate redisTemplate;
     private final OrderRepository orderRepository;
 
-    public boolean exists(String idempotencyKey) {
+    public boolean tryAcquire(String idempotencyKey) {
         try {
-            return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + idempotencyKey));
+            Boolean result = redisTemplate.opsForValue()
+                    .setIfAbsent(KEY_PREFIX + idempotencyKey, "1", TTL);
+            return Boolean.TRUE.equals(result);
         } catch (RedisConnectionFailureException e) {
             log.warn("Redis 장애 감지, DB Fallback으로 멱등성 체크: {}", e.getMessage());
-            return orderRepository.findByIdempotencyKey(idempotencyKey).isPresent();
+            return orderRepository.findByIdempotencyKey(idempotencyKey).isEmpty();
         }
     }
 
-    public void save(String idempotencyKey) {
+    public void release(String idempotencyKey) {
         try {
-            redisTemplate.opsForValue().set(KEY_PREFIX + idempotencyKey, "1", TTL);
+            redisTemplate.delete(KEY_PREFIX + idempotencyKey);
         } catch (RedisConnectionFailureException e) {
-            log.warn("Redis 장애로 멱등성 키 저장 생략 (DB UNIQUE 제약조건으로 보장): {}", e.getMessage());
+            log.warn("Redis 장애로 멱등성 키 삭제 생략: {}", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary
- `IdempotencyService`의 `exists()` + `save()`를 `tryAcquire()` (SETNX) + `release()`로 통합
- 동일 멱등성 키로 동시 요청 시 하나만 통과하도록 원자적 선점

closes #132