### PR TITLE
fix: Rate Limiting INCR+EXPIRE Lua 스크립트 원자화 (#133)

### DIFF
--- a/src/main/java/com/reservation/global/config/RedisConfig.java
+++ b/src/main/java/com/reservation/global/config/RedisConfig.java
@@ -17,4 +17,12 @@ public class RedisConfig {
         script.setResultType(Long.class);
         return script;
     }
+
+    @Bean
+    public RedisScript<Long> rateLimitScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setScriptSource(new ResourceScriptSource(new ClassPathResource("scripts/rate-limit.lua")));
+        script.setResultType(Long.class);
+        return script;
+    }
 }

--- a/src/main/java/com/reservation/global/ratelimit/RateLimitService.java
+++ b/src/main/java/com/reservation/global/ratelimit/RateLimitService.java
@@ -4,9 +4,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -15,20 +16,16 @@ public class RateLimitService {
 
     private static final String KEY_PREFIX = "ratelimit:user:";
     private static final int MAX_REQUESTS = 5;
-    private static final Duration WINDOW = Duration.ofSeconds(1);
+    private static final int WINDOW_SECONDS = 1;
 
     private final StringRedisTemplate redisTemplate;
+    private final RedisScript<Long> rateLimitScript;
 
     public boolean isAllowed(Long userId) {
         try {
             String key = KEY_PREFIX + userId;
-            Long count = redisTemplate.opsForValue().increment(key);
-
-            if (count == 1L) {
-                redisTemplate.expire(key, WINDOW);
-            }
-
-            return count <= MAX_REQUESTS;
+            Long count = redisTemplate.execute(rateLimitScript, List.of(key), String.valueOf(WINDOW_SECONDS));
+            return count != null && count <= MAX_REQUESTS;
         } catch (RedisConnectionFailureException e) {
             log.warn("Redis 장애로 Rate Limiting 비활성화: {}", e.getMessage());
             return true;

--- a/src/main/resources/scripts/rate-limit.lua
+++ b/src/main/resources/scripts/rate-limit.lua
@@ -1,0 +1,5 @@
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return count


### PR DESCRIPTION
## Summary
- `rate-limit.lua` Lua 스크립트 생성 (INCR + EXPIRE 원자적 처리)
- `RedisConfig`에 `rateLimitScript` Bean 등록
- `RateLimitService` Lua 스크립트 방식으로 변경

closes #133