### PR TITLE
feat: Checkout API Redis 재고 조회로 변경 (#134)

### DIFF
--- a/src/main/java/com/reservation/domain/order/dto/CheckoutResponse.java
+++ b/src/main/java/com/reservation/domain/order/dto/CheckoutResponse.java
@@ -1,7 +1,6 @@
 package com.reservation.domain.order.dto;
 
 import com.reservation.domain.product.entity.Product;
-import com.reservation.domain.stock.entity.Stock;
 import com.reservation.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -34,7 +33,7 @@ public record CheckoutResponse(
         int userPoint
 ) {
 
-    public static CheckoutResponse of(Product product, Stock stock, User user) {
+    public static CheckoutResponse of(Product product, int remainingStock, User user) {
         return new CheckoutResponse(
                 product.getId(),
                 product.getName(),
@@ -42,7 +41,7 @@ public record CheckoutResponse(
                 product.getCheckInTime(),
                 product.getCheckOutTime(),
                 product.getDescription(),
-                stock.getRemainingQuantity(),
+                remainingStock,
                 user.getPointBalance()
         );
     }

--- a/src/main/java/com/reservation/domain/order/service/CheckoutService.java
+++ b/src/main/java/com/reservation/domain/order/service/CheckoutService.java
@@ -3,8 +3,7 @@ package com.reservation.domain.order.service;
 import com.reservation.domain.order.dto.CheckoutResponse;
 import com.reservation.domain.product.entity.Product;
 import com.reservation.domain.product.service.ProductService;
-import com.reservation.domain.stock.entity.Stock;
-import com.reservation.domain.stock.service.StockService;
+import com.reservation.domain.stock.service.RedisStockService;
 import com.reservation.domain.user.entity.User;
 import com.reservation.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -17,13 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class CheckoutService {
 
     private final ProductService productService;
-    private final StockService stockService;
+    private final RedisStockService redisStockService;
     private final UserService userService;
 
     public CheckoutResponse getCheckout(Long productId, Long userId) {
         Product product = productService.getProduct(productId);
-        Stock stock = stockService.getStockByProductId(productId);
+        int remainingStock = redisStockService.getRemainingStock(productId);
         User user = userService.getUser(userId);
-        return CheckoutResponse.of(product, stock, user);
+        return CheckoutResponse.of(product, remainingStock, user);
     }
 }

--- a/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
+++ b/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
@@ -47,6 +47,17 @@ public class RedisStockService {
         }
     }
 
+    public int getRemainingStock(Long productId) {
+        try {
+            String key = STOCK_KEY_PREFIX + productId;
+            String value = redisTemplate.opsForValue().get(key);
+            return value != null ? Integer.parseInt(value) : 0;
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 장애 감지, DB Fallback으로 재고 조회: {}", e.getMessage());
+            return stockService.getStockByProductId(productId).getRemainingQuantity();
+        }
+    }
+
     public void initStock(Long productId, int quantity) {
         String key = STOCK_KEY_PREFIX + productId;
         redisTemplate.opsForValue().set(key, String.valueOf(quantity));


### PR DESCRIPTION
## Summary
- `RedisStockService`에 `getRemainingStock()` 추가 (Redis 장애 시 DB Fallback)
- `CheckoutService`에서 Redis 재고 조회로 변경
- `CheckoutResponse.of()` 시그니처 변경

closes #134