### PR TITLE
refactor: markFailed 불필요한 트랜잭션 제거 (#136)

### DIFF
--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -53,7 +53,6 @@ public class BookingService {
                 redisStockService.increase(product.getId());
             }
             idempotencyService.release(idempotencyKey);
-            orderTransactionService.markFailed(idempotencyKey);
             throw e;
         }
     }

--- a/src/main/java/com/reservation/domain/order/service/OrderTransactionService.java
+++ b/src/main/java/com/reservation/domain/order/service/OrderTransactionService.java
@@ -44,12 +44,6 @@ public class OrderTransactionService {
         return new OrderResult(order, payments);
     }
 
-    @Transactional
-    public void markFailed(String idempotencyKey) {
-        orderRepository.findByIdempotencyKey(idempotencyKey)
-                .ifPresent(Order::fail);
-    }
-
     public record OrderResult(Order order, List<Payment> payments) {
     }
 }


### PR DESCRIPTION
## Summary
- `OrderTransactionService.process()` 실패 시 `@Transactional` 롤백으로 주문이 DB에 남지 않으므로 `markFailed()` 호출 자체가 불필요
- `markFailed()` 메서드 및 호출부 제거

closes #136