### PR TITLE
refactor: Lua 스크립트 재고 미존재와 재고 소진 반환값 분리 (#138)

### DIFF
--- a/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
+++ b/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
@@ -27,6 +27,9 @@ public class RedisStockService {
             String key = STOCK_KEY_PREFIX + productId;
             Long result = redisTemplate.execute(decreaseStockScript, List.of(key));
 
+            if (result == -1L) {
+                throw new GeneralException(ErrorCode.STOCK_NOT_FOUND);
+            }
             if (result == 0L) {
                 throw new GeneralException(ErrorCode.STOCK_SOLD_OUT);
             }

--- a/src/main/resources/scripts/decrease-stock.lua
+++ b/src/main/resources/scripts/decrease-stock.lua
@@ -1,5 +1,8 @@
 local stock = tonumber(redis.call('GET', KEYS[1]))
-if stock == nil or stock <= 0 then
+if stock == nil then
+    return -1
+end
+if stock <= 0 then
     return 0
 end
 redis.call('DECR', KEYS[1])


### PR DESCRIPTION
## Summary
- Lua 스크립트 반환값 분리: `-1`(키 미존재), `0`(재고 소진), `1`(차감 성공)
- `RedisStockService.decrease()`에서 반환값에 따른 분기 처리

closes #138