### PR TITLE
fix: PaymentService.rollback() 결제 취소 중 예외 시 나머지 취소 중단 문제 (#155)

### DIFF
--- a/src/main/java/com/reservation/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/domain/payment/service/PaymentService.java
@@ -9,6 +9,7 @@ import com.reservation.domain.payment.repository.PaymentRepository;
 import com.reservation.domain.payment.service.strategy.PaymentStrategy;
 import com.reservation.global.exception.GeneralException;
 import com.reservation.global.exception.code.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class PaymentService {
 
@@ -86,10 +88,15 @@ public class PaymentService {
 
     private void rollback(List<Payment> completedPayments, Order order) {
         for (Payment completed : completedPayments) {
-            PaymentStrategy strategy = strategyMap.get(completed.getMethod());
-            strategy.cancel(completed, order);
-            completed.cancel();
-            paymentRepository.save(completed);
+            try {
+                PaymentStrategy strategy = strategyMap.get(completed.getMethod());
+                strategy.cancel(completed, order);
+                completed.cancel();
+                paymentRepository.save(completed);
+            } catch (Exception e) {
+                log.error("결제 취소 실패 (paymentId: {}, method: {}): {}",
+                        completed.getId(), completed.getMethod(), e.getMessage());
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `PaymentService.rollback()`에서 개별 결제 취소를 try-catch로 감싸 하나가 실패해도 나머지 취소를 계속 시도하도록 수정
- 취소 실패 시 로그 출력 추가

## Test plan
- [ ] 복합 결제(포인트 + 카드) 실패 시 보상 트랜잭션 정상 동작 확인

closes #155