### PR TITLE
fix: Checkout API Redis 재고 키 미존재 시 DB fallback 조회 (#156)

### DIFF
--- a/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
+++ b/src/main/java/com/reservation/domain/stock/service/RedisStockService.java
@@ -54,7 +54,10 @@ public class RedisStockService {
         try {
             String key = STOCK_KEY_PREFIX + productId;
             String value = redisTemplate.opsForValue().get(key);
-            return value != null ? Integer.parseInt(value) : 0;
+            if (value == null) {
+                return stockService.getStockByProductId(productId).getRemainingQuantity();
+            }
+            return Integer.parseInt(value);
         } catch (RedisConnectionFailureException e) {
             log.warn("Redis 장애 감지, DB Fallback으로 재고 조회: {}", e.getMessage());
             return stockService.getStockByProductId(productId).getRemainingQuantity();


### PR DESCRIPTION
## Summary
- `RedisStockService.getRemainingStock()`에서 Redis 키가 null일 때 0을 반환하던 것을 DB fallback 조회로 변경
- Redis 키 미존재(StockInitializer 미실행, 키 만료 등)와 실제 재고 0을 구분

## Test plan
- [ ] Redis에 키가 없는 상태에서 Checkout API 호출 시 DB 재고가 정상 반환되는지 확인

closes #156