### PR TITLE
fix: Redis 장애 시 DataIntegrityViolationException을 DUPLICATE_ORDER로 변환 (#165)

### DIFF
--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -15,6 +15,7 @@ import com.reservation.domain.user.service.UserService;
 import com.reservation.global.exception.GeneralException;
 import com.reservation.global.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -48,6 +49,11 @@ public class BookingService {
         try {
             OrderResult result = orderTransactionService.process(user, product, idempotencyKey, request, redisUsed);
             return BookingResponse.of(result.order(), result.payments());
+        } catch (DataIntegrityViolationException e) {
+            if (redisUsed) {
+                redisStockService.increase(product.getId());
+            }
+            throw new GeneralException(ErrorCode.DUPLICATE_ORDER);
         } catch (Exception e) {
             if (redisUsed) {
                 redisStockService.increase(product.getId());


### PR DESCRIPTION
## Summary
- Redis 장애 Fallback 중 동시 요청으로 인한 `DataIntegrityViolationException`을 `DUPLICATE_ORDER`(409)로 변환
- 기존 500 에러 대신 적절한 에러 코드로 응답

## Test plan
- [ ] Redis 장애 시 동일 멱등성 키로 동시 요청 시 409 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)