### PR TITLE
docs: DECISIONS.md에 Redis 재고 복구 실패 트레이드오프 추가 (#166)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -221,6 +221,7 @@ public interface PaymentStrategy {
 
 - DB Fallback 시 성능 저하는 불가피하나, 재고 10개가 빠르게 소진되므로 실제 락 경합 시간은 짧음
 - 매 요청마다 Redis를 먼저 시도하므로 Redis 복구 시 자동으로 정상 모드 복귀
+- Redis decrease 성공 후 결제 실패 시 increase로 재고를 복구하는데, 이 시점에 Redis 장애가 발생하면 Redis 재고가 DB보다 1 적게 남을 수 있음. DB 트랜잭션은 롤백되므로 DB 재고는 정상이며, 서버 재시작 시 `StockInitializer`가 DB 기준으로 Redis를 재동기화하여 해소됨
 
 ---
 


### PR DESCRIPTION
## Summary
- DECISIONS.md 쟁점 4에 Redis decrease 후 increase 실패 시 불일치 트레이드오프 추가
- 극단적 장애 시나리오에 대한 인지와 해소 방안 명시

## Test plan
- [ ] DECISIONS.md 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)