### PR TITLE
docs: AI_USAGE.md 외부 링크를 텍스트로 변경 (#167)

### DIFF
--- a/docs/AI_USAGE.md
+++ b/docs/AI_USAGE.md
@@ -4,7 +4,7 @@
 
 | 도구 | 모델 |
 |------|------|
-| [Claude Code](https://claude.com/claude-code) (CLI) | Claude Opus 4.6 |
+| Claude Code (CLI) | Claude Opus 4.6 |
 
 ## 활용 범위
 


### PR DESCRIPTION
## Summary
- AI_USAGE.md에서 불필요한 외부 링크(`https://claude.com/claude-code`) 제거

## Test plan
- [ ] AI_USAGE.md 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)