### PR TITLE
docs: 문서 정확성 및 표현 개선 (#171)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -222,6 +222,7 @@ public interface PaymentStrategy {
 - DB Fallback 시 성능 저하는 불가피하나, 재고 10개가 빠르게 소진되므로 실제 락 경합 시간은 짧음
 - 매 요청마다 Redis를 먼저 시도하므로 Redis 복구 시 자동으로 정상 모드 복귀
 - Redis decrease 성공 후 결제 실패 시 increase로 재고를 복구하는데, 이 시점에 Redis 장애가 발생하면 Redis 재고가 DB보다 1 적게 남을 수 있음. DB 트랜잭션은 롤백되므로 DB 재고는 정상이며, 서버 재시작 시 `StockInitializer`가 DB 기준으로 Redis를 재동기화하여 해소됨
+- DB Fallback으로 재고를 차감한 후 결제가 실패하면, Fallback의 `decreaseWithPessimisticLock()`이 별도 트랜잭션에서 이미 커밋되어 DB 재고가 1 적게 남을 수 있음. 이는 Redis 장애 + 결제 실패가 동시에 발생하는 극히 드문 케이스이며, 재고가 1 적게 남는 것(미달 판매)은 초과판매보다 안전한 방향임
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ docker compose up -d
 ```
 > 애플리케이션(Spring Boot) + MySQL + Redis가 모두 실행됩니다.
 
+### 종료 및 초기화
+```bash
+docker compose down -v
+```
+
 ### API 테스트
 
 Swagger UI에서 API를 직접 테스트할 수 있습니다.
@@ -99,9 +104,8 @@ http://localhost/swagger-ui/index.html
 
 > **인증/인가 참고사항**
 >
-> 본 프로젝트에서는 인증/인가 구현을 생략하였습니다.
-> 실제 환경에서는 `Authorization` 헤더의 토큰으로 사용자를 식별하지만,
-> 이를 대체하여 커스텀 헤더 `X-User-Id`로 사용자 ID를 직접 전달받는 방식을 사용합니다.
+> 본 프로젝트에서는 인증/인가 구현을 생략하였으며,
+> 커스텀 헤더 `X-User-Id`로 사용자 ID를 직접 전달받는 방식을 사용합니다.
 
 ### 1. GET /api/checkout/products/{productId} - 주문서 진입
 

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -21,7 +21,7 @@ erDiagram
         bigint product_id FK "상품 ID (UNIQUE)"
         int total_quantity "총 수량"
         int remaining_quantity "잔여 수량"
-        int version "낙관적 락 버전"
+        int version "낙관적 락 버전 (벤치마크 비교용)"
         datetime created_at "생성일시"
         datetime updated_at "수정일시"
     }
@@ -90,7 +90,7 @@ erDiagram
 | product_id | BIGINT | FK, UNIQUE, NOT NULL | 상품 ID |
 | total_quantity | INT | NOT NULL | 총 수량 |
 | remaining_quantity | INT | NOT NULL | 잔여 수량 |
-| version | INT | NOT NULL, DEFAULT 0 | 낙관적 락 버전 (Redis Fallback 시 사용) |
+| version | INT | NOT NULL, DEFAULT 0 | 낙관적 락 버전 (벤치마크 비교용) |
 | created_at | DATETIME | NOT NULL | 생성일시 |
 | updated_at | DATETIME | NOT NULL | 수정일시 |
 


### PR DESCRIPTION
## Summary
- docs/erd.md version 컬럼 설명을 벤치마크 비교용으로 수정
- README.md 인증/인가 설명에서 불필요한 표현 제거
- README.md 종료 및 초기화 방법 추가
- DECISIONS.md Redis Fallback 재고 복구 트레이드오프 추가

Closes #171

## Test plan
- [ ] 문서 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)