### PR TITLE
test: 동시 멱등성 테스트 추가 (#177)

### DIFF
--- a/src/test/java/com/reservation/domain/order/service/BookingConcurrentIdempotencyTest.java
+++ b/src/test/java/com/reservation/domain/order/service/BookingConcurrentIdempotencyTest.java
@@ -1,0 +1,116 @@
+package com.reservation.domain.order.service;
+
+import com.reservation.domain.order.dto.BookingRequest;
+import com.reservation.domain.order.repository.OrderRepository;
+import com.reservation.domain.payment.dto.PaymentRequest;
+import com.reservation.domain.payment.entity.PaymentMethod;
+import com.reservation.domain.payment.repository.PaymentRepository;
+import com.reservation.domain.product.entity.Product;
+import com.reservation.domain.product.repository.ProductRepository;
+import com.reservation.domain.stock.entity.Stock;
+import com.reservation.domain.stock.repository.StockRepository;
+import com.reservation.domain.stock.service.RedisStockService;
+import com.reservation.domain.user.entity.User;
+import com.reservation.domain.user.repository.UserRepository;
+import com.reservation.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BookingConcurrentIdempotencyTest extends IntegrationTestSupport {
+
+    @Autowired
+    private BookingService bookingService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private RedisStockService redisStockService;
+
+    private User user;
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        paymentRepository.deleteAll();
+        orderRepository.deleteAll();
+        stockRepository.deleteAll();
+        productRepository.deleteAll();
+        userRepository.deleteAll();
+
+        user = userRepository.saveAndFlush(User.create("테스트유저", "test@test.com", 100000));
+        product = productRepository.saveAndFlush(Product.create(
+                "테스트 숙소", 100000,
+                LocalTime.of(15, 0), LocalTime.of(11, 0),
+                "동시 멱등성 테스트용 상품"
+        ));
+        stockRepository.saveAndFlush(Stock.create(product, 10));
+        redisStockService.initStock(product.getId(), 10);
+    }
+
+    @DisplayName("동일 멱등성 키로 동시에 여러 요청이 들어와도 1건만 처리된다")
+    @Test
+    void concurrentRequestsWithSameKeyProcessOnlyOnce() throws Exception {
+        int threadCount = 10;
+        String idempotencyKey = UUID.randomUUID().toString();
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<Boolean>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                startLatch.await();
+                try {
+                    BookingRequest request = new BookingRequest(product.getId(), List.of(
+                            new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
+                    ));
+                    bookingService.book(user.getId(), idempotencyKey, request);
+                    return true;
+                } catch (Exception e) {
+                    return false;
+                }
+            }));
+        }
+
+        startLatch.countDown();
+
+        int successCount = 0;
+        for (Future<Boolean> future : futures) {
+            if (future.get(30, TimeUnit.SECONDS)) {
+                successCount++;
+            }
+        }
+
+        executor.shutdown();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(orderRepository.count()).isEqualTo(1);
+        assertThat(redisStockService.getRemainingStock(product.getId())).isEqualTo(9);
+    }
+}


### PR DESCRIPTION
## Summary
- 동일 멱등성 키로 10개 동시 요청 시 1건만 처리되는지 검증
- Redis SETNX 기반 원자적 선점의 동시성 안전성 증명

Closes #177

## Test plan
- [x] `./gradlew test` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)