### PR TITLE
fix: 재고 부족 시 멱등성 키 미해제 버그 및 테스트 FK 위반 수정

### DIFF
--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -44,9 +44,10 @@ public class BookingService {
         }
         User user = userService.getUser(userId);
 
-        boolean redisUsed = redisStockService.decrease(product.getId());
+        boolean redisUsed = false;
 
         try {
+            redisUsed = redisStockService.decrease(product.getId());
             OrderResult result = orderTransactionService.process(user, product, idempotencyKey, request, redisUsed);
             return BookingResponse.of(result.order(), result.payments());
         } catch (DataIntegrityViolationException e) {

--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -9,6 +9,7 @@ import com.reservation.domain.payment.entity.PaymentMethod;
 import com.reservation.domain.payment.repository.PaymentRepository;
 import com.reservation.domain.product.entity.Product;
 import com.reservation.domain.product.repository.ProductRepository;
+import com.reservation.domain.stock.repository.StockRepository;
 import com.reservation.domain.user.entity.User;
 import com.reservation.domain.user.repository.UserRepository;
 import com.reservation.global.exception.GeneralException;
@@ -50,6 +51,9 @@ class CircuitBreakerTest extends IntegrationTestSupport {
     @Autowired
     private PaymentRepository paymentRepository;
 
+    @Autowired
+    private StockRepository stockRepository;
+
     @MockBean
     private PgClient pgClient;
 
@@ -59,6 +63,7 @@ class CircuitBreakerTest extends IntegrationTestSupport {
     void setUp() {
         paymentRepository.deleteAll();
         orderRepository.deleteAll();
+        stockRepository.deleteAll();
         productRepository.deleteAll();
         userRepository.deleteAll();
 

--- a/src/test/java/com/reservation/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/PaymentServiceTest.java
@@ -9,6 +9,7 @@ import com.reservation.domain.payment.entity.PaymentStatus;
 import com.reservation.domain.payment.repository.PaymentRepository;
 import com.reservation.domain.product.entity.Product;
 import com.reservation.domain.product.repository.ProductRepository;
+import com.reservation.domain.stock.repository.StockRepository;
 import com.reservation.domain.user.entity.User;
 import com.reservation.domain.user.repository.UserRepository;
 import com.reservation.global.exception.GeneralException;
@@ -43,6 +44,9 @@ class PaymentServiceTest extends IntegrationTestSupport {
     @Autowired
     private PaymentRepository paymentRepository;
 
+    @Autowired
+    private StockRepository stockRepository;
+
     private Order order;
     private User user;
 
@@ -50,6 +54,7 @@ class PaymentServiceTest extends IntegrationTestSupport {
     void setUp() {
         paymentRepository.deleteAll();
         orderRepository.deleteAll();
+        stockRepository.deleteAll();
         productRepository.deleteAll();
         userRepository.deleteAll();
 


### PR DESCRIPTION
## Summary
- 재고 부족(`STOCK_SOLD_OUT`) 시 멱등성 키가 해제되지 않는 버그 수정 (Closes #187)
- `PaymentServiceTest`, `CircuitBreakerTest`에서 `stockRepository.deleteAll()` 누락으로 FK 제약조건 위반 테스트 실패 수정 (Closes #195)

## Changes
- `BookingService`: `decrease()` 호출을 try 블록 안으로 이동하여 모든 예외에서 멱등성 키 해제 보장
- `PaymentServiceTest`, `CircuitBreakerTest`: setUp에 `stockRepository.deleteAll()` 추가

## Test plan
- [x] 전체 테스트 통과 확인 (`./gradlew clean test` — 35/35 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)