### PR TITLE
docs: 시퀀스 다이어그램 Checkout 호출 순서 코드 일치

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,8 @@ sequenceDiagram
     participant DB as MySQL
 
     C->>S: GET /api/checkout/1 (X-User-Id: 1)
-    S->>R: 잔여 재고 조회
     S->>DB: 상품 정보 조회
+    S->>R: 잔여 재고 조회
     S->>DB: 사용자 포인트 조회
     S-->>C: 상품 정보 + 잔여 재고 + 포인트 응답
 ```

--- a/docs/sequence-diagrams.md
+++ b/docs/sequence-diagrams.md
@@ -11,16 +11,12 @@ sequenceDiagram
 
     C->>S: GET /api/checkout/products/{productId}<br/>X-User-Id: {userId}
 
-    par 병렬 조회
-        S->>R: 잔여 재고 조회 (GET stock:{productId})
-        R-->>S: remainingStock
-    and
-        S->>DB: 상품 정보 조회 (Product)
-        DB-->>S: product
-    and
-        S->>DB: 사용자 포인트 조회 (User)
-        DB-->>S: pointBalance
-    end
+    S->>DB: 상품 정보 조회 (Product)
+    DB-->>S: product
+    S->>R: 잔여 재고 조회 (GET stock:{productId})
+    R-->>S: remainingStock
+    S->>DB: 사용자 포인트 조회 (User)
+    DB-->>S: pointBalance
 
     alt 상품 없음
         S-->>C: 404 {"code": "PRODUCT001", "message": "상품을 찾을 수 없습니다."}


### PR DESCRIPTION
## Summary
- README와 docs/sequence-diagrams.md의 Checkout 시퀀스 다이어그램을 실제 코드 호출 순서(상품→Redis재고→사용자)와 일치하도록 수정 (Closes #192)
- docs의 병렬 조회(`par`) 표현을 순차 호출로 변경

## Test plan
- [x] 문서 변경만으로 코드 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)