### PR TITLE
feat: Swagger 버전에 git tag + commit hash 표시

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 .gradle
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17-jdk-jammy AS build
 
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY . .
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,13 @@ plugins {
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'org.springdoc.openapi-gradle-plugin' version '1.9.0'
+    id 'com.gorylenko.gradle-git-properties' version '2.4.2'
 }
 
+def latestGitTag = 'git describe --tags --abbrev=0'.execute().text.trim()
+
 group = 'com.reservation'
-version = '0.0.1-SNAPSHOT'
+version = latestGitTag ?: '0.0.1-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/main/java/com/reservation/global/config/SwaggerConfig.java
+++ b/src/main/java/com/reservation/global/config/SwaggerConfig.java
@@ -2,18 +2,37 @@ package com.reservation.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import org.springframework.boot.info.GitProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Optional;
+
 @Configuration
 public class SwaggerConfig {
+
+    private final Optional<GitProperties> gitProperties;
+
+    public SwaggerConfig(Optional<GitProperties> gitProperties) {
+        this.gitProperties = gitProperties;
+    }
 
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("Reservation Payment Platform API")
-                        .version("v1.0.0")
+                        .version(resolveVersion())
                         .description("선착순 예약 결제 플랫폼 API 문서"));
+    }
+
+    private String resolveVersion() {
+        return gitProperties
+                .map(git -> {
+                    String version = git.get("build.version");
+                    String commit = git.get("commit.id.abbrev");
+                    return "%s (%s)".formatted(version, commit);
+                })
+                .orElse("dev");
     }
 }


### PR DESCRIPTION
## Summary
- `gradle-git-properties` 플러그인 추가로 빌드 시 git 정보 자동 생성 (Closes #194)
- SwaggerConfig에서 `GitProperties`를 `Optional`로 주입받아 `v0.0.5 (fbaf8c9)` 형태로 버전 표시
- Dockerfile에 git 설치, `.dockerignore`에서 `.git` 제외 해제

## Test plan
- [x] `docker compose up -d --build` → Swagger UI에서 버전 확인
- [x] `curl localhost/v3/api-docs` → `"version": "v0.0.5 (fbaf8c9)"` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)