### PR TITLE
fix: 필수 헤더 누락 시 500 대신 400 응답 반환

### DIFF
--- a/src/main/java/com/reservation/global/exception/handler/GeneralExceptionHandler.java
+++ b/src/main/java/com/reservation/global/exception/handler/GeneralExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
@@ -45,6 +46,12 @@ public class GeneralExceptionHandler {
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     protected ResponseEntity<ErrorResponse<Void>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        log.warn("{} : {}", ex.getClass().getSimpleName(), ex.getMessage());
+        return ErrorResponse.handle(ErrorCode.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
         log.warn("{} : {}", ex.getClass().getSimpleName(), ex.getMessage());
         return ErrorResponse.handle(ErrorCode.BAD_REQUEST);
     }


### PR DESCRIPTION
## Summary
- `MissingRequestHeaderException` 핸들러 추가하여 필수 헤더 누락 시 400 반환 (Closes #206)

## Test plan
- [x] `curl -X POST /api/bookings` (헤더 없이) → 400 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)