### PR TITLE
fix: 포인트 차감 Race Condition 비관적 락 적용

### DIFF
--- a/src/main/java/com/reservation/domain/payment/service/strategy/YPointPaymentStrategy.java
+++ b/src/main/java/com/reservation/domain/payment/service/strategy/YPointPaymentStrategy.java
@@ -25,7 +25,7 @@ public class YPointPaymentStrategy implements PaymentStrategy {
 
     @Override
     public void pay(Payment payment, Order order) {
-        User user = userRepository.findById(order.getUser().getId())
+        User user = userRepository.findWithLockById(order.getUser().getId())
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
         if (user.getPointBalance() < payment.getAmount()) {

--- a/src/main/java/com/reservation/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/reservation/domain/user/repository/UserRepository.java
@@ -1,7 +1,14 @@
 package com.reservation.domain.user.repository;
 
 import com.reservation.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<User> findWithLockById(Long id);
 }


### PR DESCRIPTION
## Summary
- `UserRepository.findWithLockById()` 추가 (비관적 락) (Closes #208)
- `YPointPaymentStrategy`에서 비관적 락으로 사용자 조회하여 동시 포인트 차감 방지

## Test plan
- [x] 기존 PaymentServiceTest 포인트 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)