### PR TITLE
fix: 서킷브레이커 에러코드 오기 수정 및 포인트 동시성 보강

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -449,7 +449,31 @@ self-invocation 시 Spring AOP 프록시가 동작하지 않는 문제를 방지
 
 ---
 
-## 쟁점 10. 동일 사용자 중복 구매 제한 미적용
+## 쟁점 10. 포인트 차감 동시성 제어
+
+> 동일 사용자가 동시에 여러 주문을 생성하면 포인트 잔액 검증과 차감 사이에 Race Condition이 발생할 수 있는 문제
+
+### 상황
+
+`YPointPaymentStrategy`에서 포인트 잔액 확인(`getPointBalance()`) 후 차감(`deductPoints()`)하는 사이에 다른 트랜잭션이 동일 사용자의 포인트를 차감하면, 잔액이 음수가 될 수 있습니다.
+
+### 선택지
+
+| 방식 | 핵심 원리 |
+|------|---------|
+| 낙관적 락 (@Version) | 충돌 시 재시도, 포인트 차감은 단순 연산이므로 재시도 비용 낮음 |
+| 비관적 락 (SELECT FOR UPDATE) | 사용자 row에 쓰기 락, 순차 처리 보장 |
+| UPDATE WHERE 조건부 | `UPDATE users SET point_balance = point_balance - ? WHERE point_balance >= ?` |
+
+### 최종 선택: 비관적 락
+
+- 재고 관리의 DB Fallback에서도 비관적 락(`findWithLockByProductId`)을 사용하므로, 동일 패턴으로 일관성 유지
+- 포인트 차감은 결제 트랜잭션 내에서 실행되므로 락 점유 시간이 짧음
+- `UserRepository.findWithLockById()`로 사용자를 조회하여 잔액 검증과 차감이 원자적으로 처리됨
+
+---
+
+## 쟁점 11. 동일 사용자 중복 구매 제한 미적용
 
 현재 구조에서는 같은 사용자가 다른 멱등성 키로 동일 상품을 여러 번 예약할 수 있습니다. 이는 의도적인 판단입니다.
 

--- a/docs/sequence-diagrams.md
+++ b/docs/sequence-diagrams.md
@@ -220,7 +220,7 @@ sequenceDiagram
     C->>S: 결제 요청
     S->>CB: PG 호출 시도
     CB-->>S: 서킷 오픈 (즉시 실패)
-    S-->>C: 503 {"code": "PAYMENT005",<br/>"message": "결제 서비스가 일시적으로 불가합니다."}
+    S-->>C: 503 {"code": "PAYMENT006",<br/>"message": "결제 서비스를 일시적으로 이용할 수 없습니다."}
 
     Note over CB: 대기 시간 경과 → HALF_OPEN
 

--- a/src/test/java/com/reservation/domain/order/service/BookingPointConcurrencyTest.java
+++ b/src/test/java/com/reservation/domain/order/service/BookingPointConcurrencyTest.java
@@ -1,0 +1,120 @@
+package com.reservation.domain.order.service;
+
+import com.reservation.domain.order.dto.BookingRequest;
+import com.reservation.domain.order.repository.OrderRepository;
+import com.reservation.domain.payment.dto.PaymentRequest;
+import com.reservation.domain.payment.entity.PaymentMethod;
+import com.reservation.domain.payment.repository.PaymentRepository;
+import com.reservation.domain.product.entity.Product;
+import com.reservation.domain.product.repository.ProductRepository;
+import com.reservation.domain.stock.entity.Stock;
+import com.reservation.domain.stock.repository.StockRepository;
+import com.reservation.domain.stock.service.RedisStockService;
+import com.reservation.domain.user.entity.User;
+import com.reservation.domain.user.repository.UserRepository;
+import com.reservation.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BookingPointConcurrencyTest extends IntegrationTestSupport {
+
+    @Autowired
+    private BookingService bookingService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private RedisStockService redisStockService;
+
+    private User user;
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        paymentRepository.deleteAll();
+        orderRepository.deleteAll();
+        stockRepository.deleteAll();
+        productRepository.deleteAll();
+        userRepository.deleteAll();
+
+        user = userRepository.saveAndFlush(User.create("테스트유저", "test@test.com", 100000));
+        product = productRepository.saveAndFlush(Product.create(
+                "테스트 숙소", 50000,
+                LocalTime.of(15, 0), LocalTime.of(11, 0),
+                "포인트 동시성 테스트용 상품"
+        ));
+        stockRepository.saveAndFlush(Stock.create(product, 10));
+        redisStockService.initStock(product.getId(), 10);
+    }
+
+    @DisplayName("동일 사용자가 포인트로 동시에 주문하면 잔액이 음수가 되지 않는다")
+    @Test
+    void concurrentPointPaymentPreventsNegativeBalance() throws Exception {
+        int concurrentRequests = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(concurrentRequests);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<Boolean>> futures = new ArrayList<>();
+
+        for (int i = 0; i < concurrentRequests; i++) {
+            futures.add(executor.submit(() -> {
+                startLatch.await();
+                try {
+                    BookingRequest request = new BookingRequest(product.getId(), List.of(
+                            new PaymentRequest(PaymentMethod.Y_POINT, 50000)
+                    ));
+                    bookingService.book(user.getId(), UUID.randomUUID().toString(), request);
+                    return true;
+                } catch (Exception e) {
+                    return false;
+                }
+            }));
+        }
+
+        startLatch.countDown();
+
+        int successCount = 0;
+        for (Future<Boolean> future : futures) {
+            if (future.get(30, TimeUnit.SECONDS)) {
+                successCount++;
+            }
+        }
+
+        executor.shutdown();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+
+        // 100000 포인트, 50000원 상품 → 최대 2건 성공 가능 (락 경합으로 더 적을 수 있음)
+        assertThat(successCount).isLessThanOrEqualTo(2);
+        assertThat(successCount).isGreaterThanOrEqualTo(1);
+
+        User updatedUser = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(updatedUser.getPointBalance()).isGreaterThanOrEqualTo(0);
+        assertThat(updatedUser.getPointBalance()).isEqualTo(100000 - (successCount * 50000));
+    }
+}


### PR DESCRIPTION
## Summary
- docs/sequence-diagrams.md 서킷 오픈 에러코드 `PAYMENT005` → `PAYMENT006` 수정 (Closes #212)
- DECISIONS.md 쟁점 10에 포인트 Race Condition 해결 근거 추가
- 포인트 동시 차감 동시성 테스트 추가 (잔액 음수 방지 검증)

## Test plan
- [x] BookingPointConcurrencyTest 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)