### PR TITLE
fix: YPointPaymentStrategy.cancel() 비관적 락 적용 (#215)

### DIFF
--- a/src/main/java/com/reservation/domain/payment/service/strategy/YPointPaymentStrategy.java
+++ b/src/main/java/com/reservation/domain/payment/service/strategy/YPointPaymentStrategy.java
@@ -39,7 +39,8 @@ public class YPointPaymentStrategy implements PaymentStrategy {
 
     @Override
     public void cancel(Payment payment, Order order) {
-        User user = userRepository.findById(order.getUser().getId()).orElseThrow();
+        User user = userRepository.findWithLockById(order.getUser().getId())
+                .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
         user.restorePoints(payment.getAmount());
     }
 }


### PR DESCRIPTION
포인트 환불 시 findById() → findWithLockById()로 변경