### PR TITLE
fix: DataIntegrityViolationException 발생 시 멱등성 키 처리 개선 (#217)

### DIFF
--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -54,7 +54,12 @@ public class BookingService {
             if (redisUsed) {
                 redisStockService.increase(product.getId());
             }
-            throw new GeneralException(ErrorCode.DUPLICATE_ORDER);
+            return orderRepository.findByIdempotencyKey(idempotencyKey)
+                    .map(existingOrder -> BookingResponse.of(existingOrder, paymentRepository.findByOrderId(existingOrder.getId())))
+                    .orElseThrow(() -> {
+                        idempotencyService.release(idempotencyKey);
+                        return new GeneralException(ErrorCode.DUPLICATE_ORDER);
+                    });
         } catch (Exception e) {
             if (redisUsed) {
                 redisStockService.increase(product.getId());


### PR DESCRIPTION
idempotencyKey UNIQUE 위반 시 기존 주문 반환, 그 외 위반 시 키 해제