### PR TITLE
fix: ExternalPaymentStrategy 예외 로깅 추가 및 에러코드 개선 (#218)

### DIFF
--- a/src/main/java/com/reservation/domain/payment/service/strategy/ExternalPaymentStrategy.java
+++ b/src/main/java/com/reservation/domain/payment/service/strategy/ExternalPaymentStrategy.java
@@ -9,7 +9,9 @@ import com.reservation.global.exception.code.ErrorCode;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public abstract class ExternalPaymentStrategy implements PaymentStrategy {
 
     private final ExternalPaymentClient client;
@@ -29,8 +31,9 @@ public abstract class ExternalPaymentStrategy implements PaymentStrategy {
             payment.fail();
             throw new GeneralException(ErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
+            log.error("외부 결제 실패 (method: {}, amount: {}): {}", payment.getMethod(), payment.getAmount(), e.getMessage(), e);
             payment.fail();
-            throw new GeneralException(ErrorCode.PAYMENT_TIMEOUT);
+            throw new GeneralException(ErrorCode.PAYMENT_FAILED);
         }
 
         if (!result.success()) {

--- a/src/test/java/com/reservation/domain/order/service/BookingCompensationTest.java
+++ b/src/test/java/com/reservation/domain/order/service/BookingCompensationTest.java
@@ -119,9 +119,9 @@ class BookingCompensationTest extends IntegrationTestSupport {
         assertThat(orderRepository.count()).isZero();
     }
 
-    @DisplayName("카드 타임아웃 시 재고가 복구되고 멱등성 키가 해제되어 재시도 가능하다")
+    @DisplayName("카드 결제 예외 시 재고가 복구되고 멱등성 키가 해제되어 재시도 가능하다")
     @Test
-    void retryAllowedAfterTimeout() {
+    void retryAllowedAfterPaymentFailure() {
         when(pgClient.pay(anyInt()))
                 .thenThrow(new RuntimeException("Connection timeout"))
                 .thenReturn(PaymentResult.success("txn-001"));
@@ -134,7 +134,7 @@ class BookingCompensationTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> bookingService.book(user.getId(), idempotencyKey, request))
                 .isInstanceOf(GeneralException.class)
                 .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
-                        .isEqualTo(ErrorCode.PAYMENT_TIMEOUT));
+                        .isEqualTo(ErrorCode.PAYMENT_FAILED));
 
         assertThat(redisStockService.getRemainingStock(product.getId())).isEqualTo(10);
 

--- a/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/CircuitBreakerTest.java
@@ -111,9 +111,9 @@ class CircuitBreakerTest extends IntegrationTestSupport {
                         .isEqualTo(ErrorCode.PAYMENT_LIMIT_EXCEEDED));
     }
 
-    @DisplayName("PG 타임아웃 시 PAYMENT_TIMEOUT 반환")
+    @DisplayName("PG 예외 발생 시 PAYMENT_FAILED 반환")
     @Test
-    void timeoutReturnsError() {
+    void exceptionReturnsPaymentFailed() {
         when(pgClient.pay(anyInt())).thenThrow(new RuntimeException("Connection timeout"));
 
         assertThatThrownBy(() -> paymentService.pay(order, List.of(
@@ -121,7 +121,7 @@ class CircuitBreakerTest extends IntegrationTestSupport {
         ), 100000))
                 .isInstanceOf(GeneralException.class)
                 .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
-                        .isEqualTo(ErrorCode.PAYMENT_TIMEOUT));
+                        .isEqualTo(ErrorCode.PAYMENT_FAILED));
     }
 
     @DisplayName("연속 실패 시 서킷이 OPEN되고 PAYMENT_SERVICE_UNAVAILABLE 반환")


### PR DESCRIPTION
모든 예외를 PAYMENT_TIMEOUT → PAYMENT_FAILED로 변경, 원본 예외 로깅 추가