### PR TITLE
fix: PaymentService.rollback() 취소 실패 시 CANCEL_FAILED 상태 기록 (#219)

### DIFF
--- a/src/main/java/com/reservation/domain/payment/entity/Payment.java
+++ b/src/main/java/com/reservation/domain/payment/entity/Payment.java
@@ -55,4 +55,8 @@ public class Payment extends BaseEntity {
     public void cancel() {
         this.status = PaymentStatus.CANCELLED;
     }
+
+    public void cancelFailed() {
+        this.status = PaymentStatus.CANCEL_FAILED;
+    }
 }

--- a/src/main/java/com/reservation/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/reservation/domain/payment/entity/PaymentStatus.java
@@ -4,5 +4,6 @@ public enum PaymentStatus {
     PENDING,
     APPROVED,
     FAILED,
-    CANCELLED
+    CANCELLED,
+    CANCEL_FAILED
 }

--- a/src/main/java/com/reservation/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/domain/payment/service/PaymentService.java
@@ -92,11 +92,12 @@ public class PaymentService {
                 PaymentStrategy strategy = strategyMap.get(completed.getMethod());
                 strategy.cancel(completed, order);
                 completed.cancel();
-                paymentRepository.save(completed);
             } catch (Exception e) {
-                log.error("결제 취소 실패 (paymentId: {}, method: {}): {}",
-                        completed.getId(), completed.getMethod(), e.getMessage());
+                log.error("결제 취소 실패 (paymentId: {}, method: {}, transactionId: {}): {}",
+                        completed.getId(), completed.getMethod(), completed.getTransactionId(), e.getMessage(), e);
+                completed.cancelFailed();
             }
+            paymentRepository.save(completed);
         }
     }
 }


### PR DESCRIPTION
결제 취소 실패 시 CANCEL_FAILED 상태로 DB에 기록하여 추적 가능하도록 개선