### PR TITLE
fix: RateLimitInterceptor userIdHeader 파싱 예외 시 400 응답 (#220)

### DIFF
--- a/src/main/java/com/reservation/global/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/reservation/global/ratelimit/RateLimitInterceptor.java
@@ -22,7 +22,12 @@ public class RateLimitInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        Long userId = Long.valueOf(userIdHeader);
+        Long userId;
+        try {
+            userId = Long.valueOf(userIdHeader);
+        } catch (NumberFormatException e) {
+            throw new GeneralException(ErrorCode.BAD_REQUEST);
+        }
         if (!rateLimitService.isAllowed(userId)) {
             throw new GeneralException(ErrorCode.RATE_LIMIT_EXCEEDED);
         }


### PR DESCRIPTION
NumberFormatException → 500 대신 BAD_REQUEST 400 반환