### PR TITLE
fix: CircuitBreakerRegistry 명시적 빈 등록으로 CI 테스트 수정 (#216)

### DIFF
--- a/src/main/java/com/reservation/global/config/CircuitBreakerConfig.java
+++ b/src/main/java/com/reservation/global/config/CircuitBreakerConfig.java
@@ -1,0 +1,29 @@
+package com.reservation.global.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class CircuitBreakerConfig {
+
+    @Bean
+    public CircuitBreakerRegistry circuitBreakerRegistry() {
+        io.github.resilience4j.circuitbreaker.CircuitBreakerConfig config =
+                io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.custom()
+                        .slidingWindowType(io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                        .slidingWindowSize(10)
+                        .failureRateThreshold(50)
+                        .waitDurationInOpenState(Duration.ofSeconds(10))
+                        .permittedNumberOfCallsInHalfOpenState(3)
+                        .minimumNumberOfCalls(5)
+                        .build();
+
+        CircuitBreakerRegistry registry = CircuitBreakerRegistry.of(config);
+        registry.circuitBreaker("creditCard");
+        registry.circuitBreaker("yPay");
+        return registry;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,24 +27,6 @@ springdoc:
   api-docs:
     path: /v3/api-docs
 
-resilience4j:
-  circuitbreaker:
-    instances:
-      creditCard:
-        sliding-window-type: COUNT_BASED
-        sliding-window-size: 10
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 10s
-        permitted-number-of-calls-in-half-open-state: 3
-        minimum-number-of-calls: 5
-      yPay:
-        sliding-window-type: COUNT_BASED
-        sliding-window-size: 10
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 10s
-        permitted-number-of-calls-in-half-open-state: 3
-        minimum-number-of-calls: 5
-
 ---
 spring:
   config:


### PR DESCRIPTION
YAML auto-config 대신 프로그래밍 방식으로 CircuitBreakerRegistry를 등록하여 설정 적용 보장