### PR TITLE
refactor: Redis Fallback 시 로컬 메모리 Rate Limiting 추가 (#224)

### DIFF
--- a/src/main/java/com/reservation/global/ratelimit/RateLimitService.java
+++ b/src/main/java/com/reservation/global/ratelimit/RateLimitService.java
@@ -8,6 +8,8 @@ import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Service
@@ -20,6 +22,8 @@ public class RateLimitService {
 
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<Long> rateLimitScript;
+    private final ConcurrentHashMap<Long, AtomicInteger> localLimitMap = new ConcurrentHashMap<>();
+    private volatile long localWindowStart = System.currentTimeMillis();
 
     public boolean isAllowed(Long userId) {
         try {
@@ -27,8 +31,18 @@ public class RateLimitService {
             Long count = redisTemplate.execute(rateLimitScript, List.of(key), String.valueOf(WINDOW_SECONDS));
             return count != null && count <= MAX_REQUESTS;
         } catch (RedisConnectionFailureException e) {
-            log.warn("Redis 장애로 Rate Limiting 비활성화: {}", e.getMessage());
-            return true;
+            log.warn("Redis 장애로 로컬 Rate Limiting 적용: {}", e.getMessage());
+            return isAllowedLocal(userId);
         }
+    }
+
+    private boolean isAllowedLocal(Long userId) {
+        long now = System.currentTimeMillis();
+        if (now - localWindowStart > WINDOW_SECONDS * 1000L) {
+            localLimitMap.clear();
+            localWindowStart = now;
+        }
+        AtomicInteger counter = localLimitMap.computeIfAbsent(userId, k -> new AtomicInteger(0));
+        return counter.incrementAndGet() <= MAX_REQUESTS;
     }
 }


### PR DESCRIPTION
Redis 장애 시 ConcurrentHashMap 기반 로컬 Rate Limiting으로 서버 보호