### PR TITLE
refactor: 상품 정보 로컬 캐싱 제거 (#250)

### DIFF
--- a/src/main/java/com/reservation/domain/order/controller/CheckoutController.java
+++ b/src/main/java/com/reservation/domain/order/controller/CheckoutController.java
@@ -23,7 +23,7 @@ public class CheckoutController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiResponse(responseCode = "404", description = "상품 또는 사용자를 찾을 수 없음")
     @GetMapping("/products/{productId}")
-    public ResponseEntity<CheckoutResponse> checkout(
+    public ResponseEntity<CheckoutResponse> getCheckout(
             @Parameter(description = "상품 ID") @PathVariable Long productId,
             @Parameter(description = "사용자 ID", required = true) @RequestHeader(HeaderConstants.USER_ID) Long userId) {
         CheckoutResponse response = checkoutService.getCheckout(productId, userId);

--- a/src/main/java/com/reservation/domain/product/service/ProductService.java
+++ b/src/main/java/com/reservation/domain/product/service/ProductService.java
@@ -8,25 +8,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProductService {
 
     private final ProductRepository productRepository;
-    private final ConcurrentHashMap<Long, Product> productCache = new ConcurrentHashMap<>();
 
     public Product getProduct(Long productId) {
-        Product cached = productCache.get(productId);
-        if (cached != null) {
-            return cached;
-        }
-
-        Product product = productRepository.findById(productId)
+        return productRepository.findById(productId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.PRODUCT_NOT_FOUND));
-        productCache.put(productId, product);
-        return product;
     }
 }


### PR DESCRIPTION
## Summary
- ProductService에서 `ConcurrentHashMap` 기반 인메모리 캐시 제거, 단순 DB 조회로 변경
- CheckoutController 메서드명 `checkout` → `getCheckout`으로 Service와 네이밍 통일

## 제거 근거
- 상품 10개 PK 조회는 DB에 부담이 되지 않는 수준
- JPA 1차 캐시가 동일 트랜잭션 내 중복 조회 방지
- 캐시 도입 시 TTL, 만료 전략 등 부가 복잡도 대비 이점이 작음

## Test plan
- [x] 빌드 성공 확인
- [ ] CI 통과 확인

closes #250