### PR TITLE
fix: PaymentStrategy 미등록 결제 수단에 대한 방어 로직 추가

### DIFF
--- a/src/main/java/com/reservation/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/domain/payment/service/PaymentService.java
@@ -49,7 +49,7 @@ public class PaymentService {
                         .amount(request.amount())
                         .build();
 
-                PaymentStrategy strategy = strategyMap.get(request.method());
+                PaymentStrategy strategy = getStrategy(request.method());
                 strategy.pay(payment, order);
 
                 paymentRepository.save(payment);
@@ -86,10 +86,18 @@ public class PaymentService {
                 .toList();
     }
 
+    private PaymentStrategy getStrategy(PaymentMethod method) {
+        PaymentStrategy strategy = strategyMap.get(method);
+        if (strategy == null) {
+            throw new GeneralException(ErrorCode.UNSUPPORTED_PAYMENT_METHOD);
+        }
+        return strategy;
+    }
+
     private void rollback(List<Payment> completedPayments, Order order) {
         for (Payment completed : completedPayments) {
             try {
-                PaymentStrategy strategy = strategyMap.get(completed.getMethod());
+                PaymentStrategy strategy = getStrategy(completed.getMethod());
                 strategy.cancel(completed, order);
                 completed.cancel();
             } catch (Exception e) {

--- a/src/main/java/com/reservation/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/reservation/global/exception/code/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     PAYMENT_TIMEOUT(503, "PAYMENT005", "결제 요청 시간이 초과되었습니다."),
     PAYMENT_SERVICE_UNAVAILABLE(503, "PAYMENT006", "결제 서비스를 일시적으로 이용할 수 없습니다."),
     INVALID_PAYMENT_AMOUNT(400, "PAYMENT007", "결제 금액 합계가 상품 가격과 일치하지 않습니다."),
+    UNSUPPORTED_PAYMENT_METHOD(400, "PAYMENT008", "지원하지 않는 결제 수단입니다."),
 
     // Order
     DUPLICATE_ORDER(409, "ORDER001", "이미 처리된 요청입니다."),

--- a/src/test/java/com/reservation/domain/payment/service/PaymentServiceUnsupportedStrategyTest.java
+++ b/src/test/java/com/reservation/domain/payment/service/PaymentServiceUnsupportedStrategyTest.java
@@ -1,0 +1,56 @@
+package com.reservation.domain.payment.service;
+
+import com.reservation.domain.order.entity.Order;
+import com.reservation.domain.payment.dto.PaymentRequest;
+import com.reservation.domain.payment.entity.Payment;
+import com.reservation.domain.payment.entity.PaymentMethod;
+import com.reservation.domain.payment.repository.PaymentRepository;
+import com.reservation.domain.payment.service.strategy.PaymentStrategy;
+import com.reservation.global.exception.GeneralException;
+import com.reservation.global.exception.code.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class PaymentServiceUnsupportedStrategyTest {
+
+    @DisplayName("결제 수단에 해당하는 Strategy가 없으면 명시적인 예외가 발생한다")
+    @Test
+    void unsupportedPaymentMethodFails() {
+        PaymentService paymentService = new PaymentService(
+                mock(PaymentRepository.class),
+                List.of(new StubPaymentStrategy(PaymentMethod.CREDIT_CARD))
+        );
+
+        assertThatThrownBy(() -> paymentService.pay(
+                mock(Order.class),
+                List.of(new PaymentRequest(PaymentMethod.Y_PAY, 100000)),
+                100000
+        ))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.UNSUPPORTED_PAYMENT_METHOD));
+    }
+
+    private record StubPaymentStrategy(PaymentMethod method) implements PaymentStrategy {
+
+        @Override
+        public PaymentMethod getMethod() {
+            return method;
+        }
+
+        @Override
+        public void pay(Payment payment, Order order) {
+            payment.approve("test-transaction-id");
+        }
+
+        @Override
+        public void cancel(Payment payment, Order order) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `PaymentService`에서 `strategyMap.get()` null 반환 시 NPE 대신 명확한 예외 반환
- `getStrategy()` 메서드 추출로 pay/rollback 양쪽에서 일관된 방어
- `ErrorCode.UNSUPPORTED_PAYMENT_METHOD` (PAYMENT008) 추가

closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)