### PR TITLE
fix: Redis fallback 결제 실패 시 DB 재고 복구 보강 (#260)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -292,7 +292,7 @@ Nginx 기본 round-robin을 사용합니다. 재고 차감은 Redis 단일 스�
 - DB Fallback 시 성능 저하는 불가피하나, 재고 10개가 빠르게 소진되므로 실제 락 경합 시간은 짧음
 - 서킷 오픈 중에는 정상 요청도 즉시 실패하지만, PG 장애 상태에서 어차피 실패할 요청으로 서버 자원을 낭비하는 것보다 나음
 - Redis decrease 성공 후 결제 실패 시 increase로 재고를 복구하는데, 이 시점에 Redis 장애가 발생하면 Redis 재고가 DB보다 1 적게 남을 수 있음. DB 트랜잭션은 롤백되므로 DB 재고는 정상이며, 서버 재시작 시 `StockInitializer`가 DB 기준으로 Redis를 재동기화하여 해소됨
-- DB Fallback으로 재고를 차감한 후 결제가 실패하면, `decreaseWithPessimisticLock()`이 별도 트랜잭션에서 이미 커밋되어 DB 재고가 1 적게 남을 수 있음. 이는 Redis 장애 + 결제 실패가 동시에 발생하는 극히 드문 케이스이며, 재고가 1 적게 남는 것(미달 판매)은 초과판매보다 안전한 방향임
+- DB Fallback으로 재고를 차감한 후 결제가 실패하면, `decreaseWithPessimisticLock()`이 별도 트랜잭션에서 이미 커밋되어 있으므로 `increaseWithPessimisticLock()`으로 보상 복구 처리. Redis 정상 경로와 동일하게 결제 실패 시 재고가 원상 복구됨
 
 ---
 
@@ -354,10 +354,10 @@ Nginx 기본 round-robin을 사용합니다. 재고 차감은 Redis 단일 스�
 | 실패 지점 | 보상 동작 |
 |----------|---------|
 | 오픈 시간 검증 실패 | 멱등성 키 해제 (release) |
-| 결제 금액 불일치 | 멱등성 키 해제 + Redis 재고 복구 (INCR) |
-| 결제 중 포인트 부족 | 멱등성 키 해제 + Redis 재고 복구 (INCR) |
-| 결제 중 외부 결제 실패 | 포인트 환불 + 멱등성 키 해제 + Redis 재고 복구 |
-| DB 저장 실패 | 결제 취소 + 포인트 환불 + 멱등성 키 해제 + Redis 재고 복구 (DB는 트랜잭션 롤백) |
+| 결제 금액 불일치 | 멱등성 키 해제 + 재고 복구 (Redis INCR 또는 DB increase) |
+| 결제 중 포인트 부족 | 멱등성 키 해제 + 재고 복구 (Redis INCR 또는 DB increase) |
+| 결제 중 외부 결제 실패 | 포인트 환불 + 멱등성 키 해제 + 재고 복구 (Redis INCR 또는 DB increase) |
+| DB 저장 실패 | 결제 취소 + 포인트 환불 + 멱등성 키 해제 + 재고 복구 (Redis INCR 또는 DB increase) |
 
 결제 내부의 보상(포인트 환불, 외부 결제 취소)은 `PaymentService.rollback()`이 Strategy별 `cancel()`로 처리하고, Redis 재고 복구와 멱등성 키 해제는 `BookingService`에서 처리합니다.
 

--- a/docs/sequence-diagrams.md
+++ b/docs/sequence-diagrams.md
@@ -184,7 +184,7 @@ sequenceDiagram
     S->>PG: 결제 승인 요청
     alt 결제 실패
         PG-->>S: 승인 실패
-        Note over S: DB Fallback 차감은 이미 커밋됨<br/>현재 구현은 재고 복구 없이 미달 판매를 허용
+        S->>DB: DB 재고 복구 (increaseWithPessimisticLock)
         Note over DB: 주문은 트랜잭션 롤백으로 저장되지 않음
         S-->>C: 400/500/503 결제 실패
     end
@@ -194,7 +194,7 @@ sequenceDiagram
     S->>DB: 주문 COMPLETED
     S-->>C: 200 예약 완료
 
-    Note over S: Redis 복구 시 재고 동기화 필요
+    Note over S: Redis 복구 시 StockInitializer가 DB 기준으로 재동기화
 ```
 
 ---

--- a/src/main/java/com/reservation/domain/order/service/BookingService.java
+++ b/src/main/java/com/reservation/domain/order/service/BookingService.java
@@ -10,6 +10,7 @@ import com.reservation.domain.payment.repository.PaymentRepository;
 import com.reservation.domain.product.entity.Product;
 import com.reservation.domain.product.service.ProductService;
 import com.reservation.domain.stock.service.RedisStockService;
+import com.reservation.domain.stock.service.StockService;
 import com.reservation.domain.user.service.UserService;
 import com.reservation.global.exception.GeneralException;
 import com.reservation.global.exception.code.ErrorCode;
@@ -26,6 +27,7 @@ public class BookingService {
     private final ProductService productService;
     private final UserService userService;
     private final RedisStockService redisStockService;
+    private final StockService stockService;
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
     private final OrderTransactionService orderTransactionService;
@@ -44,14 +46,16 @@ public class BookingService {
         userService.getUser(userId);
 
         boolean redisUsed = false;
+        boolean stockDecreased = false;
 
         try {
             redisUsed = redisStockService.decrease(product.getId());
+            stockDecreased = true;
             OrderResult result = orderTransactionService.process(userId, product, idempotencyKey, request, redisUsed);
             return BookingResponse.of(result.order(), result.payments());
         } catch (DataIntegrityViolationException e) {
-            if (redisUsed) {
-                redisStockService.increase(product.getId());
+            if (stockDecreased) {
+                restoreStock(product.getId(), redisUsed);
             }
             return orderRepository.findByIdempotencyKey(idempotencyKey)
                     .map(existingOrder -> BookingResponse.of(existingOrder, paymentRepository.findByOrderId(existingOrder.getId())))
@@ -60,12 +64,20 @@ public class BookingService {
                         return new GeneralException(ErrorCode.DUPLICATE_ORDER);
                     });
         } catch (Exception e) {
-            if (redisUsed) {
-                redisStockService.increase(product.getId());
+            if (stockDecreased) {
+                restoreStock(product.getId(), redisUsed);
             }
             idempotencyService.release(idempotencyKey);
             orderTransactionService.logFailure(userId, product.getId(), idempotencyKey, e.getMessage());
             throw e;
+        }
+    }
+
+    private void restoreStock(Long productId, boolean redisUsed) {
+        if (redisUsed) {
+            redisStockService.increase(productId);
+        } else {
+            stockService.increaseWithPessimisticLock(productId);
         }
     }
 

--- a/src/main/java/com/reservation/domain/stock/service/StockService.java
+++ b/src/main/java/com/reservation/domain/stock/service/StockService.java
@@ -28,4 +28,12 @@ public class StockService {
 
         stock.decrease();
     }
+
+    @Transactional
+    public void increaseWithPessimisticLock(Long productId) {
+        Stock stock = stockRepository.findWithLockByProductId(productId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.STOCK_NOT_FOUND));
+
+        stock.increase();
+    }
 }

--- a/src/test/java/com/reservation/domain/order/service/BookingRedisFallbackTest.java
+++ b/src/test/java/com/reservation/domain/order/service/BookingRedisFallbackTest.java
@@ -4,6 +4,8 @@ import com.reservation.domain.order.dto.BookingRequest;
 import com.reservation.domain.order.dto.BookingResponse;
 import com.reservation.domain.order.entity.OrderStatus;
 import com.reservation.domain.order.repository.OrderRepository;
+import com.reservation.domain.payment.client.PaymentResult;
+import com.reservation.domain.payment.client.PgClient;
 import com.reservation.domain.payment.dto.PaymentRequest;
 import com.reservation.domain.payment.entity.PaymentMethod;
 import com.reservation.domain.payment.repository.PaymentRepository;
@@ -13,11 +15,14 @@ import com.reservation.domain.stock.entity.Stock;
 import com.reservation.domain.stock.repository.StockRepository;
 import com.reservation.domain.user.entity.User;
 import com.reservation.domain.user.repository.UserRepository;
+import com.reservation.global.exception.GeneralException;
+import com.reservation.global.exception.code.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
@@ -27,6 +32,9 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class BookingRedisFallbackTest {
@@ -46,6 +54,9 @@ class BookingRedisFallbackTest {
         registry.add("spring.data.redis.host", () -> "localhost");
         registry.add("spring.data.redis.port", () -> "1");
     }
+
+    @MockBean
+    private PgClient pgClient;
 
     @Autowired
     private BookingService bookingService;
@@ -88,6 +99,8 @@ class BookingRedisFallbackTest {
     @DisplayName("Redis 장애 시 DB Fallback으로 예약이 정상 처리된다")
     @Test
     void bookingSucceedsWithDbFallback() {
+        when(pgClient.pay(anyInt())).thenReturn(PaymentResult.success("txn-fallback-001"));
+
         BookingRequest request = new BookingRequest(product.getId(), List.of(
                 new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
         ));
@@ -101,9 +114,30 @@ class BookingRedisFallbackTest {
         assertThat(stock.getRemainingQuantity()).isEqualTo(9);
     }
 
+    @DisplayName("Redis 장애 시 결제 실패하면 DB 재고가 복구된다")
+    @Test
+    void dbStockRestoredWhenPaymentFailsInFallback() {
+        when(pgClient.pay(anyInt())).thenReturn(PaymentResult.failure(ErrorCode.PAYMENT_FAILED));
+
+        BookingRequest request = new BookingRequest(product.getId(), List.of(
+                new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
+        ));
+
+        assertThatThrownBy(() -> bookingService.book(user.getId(), UUID.randomUUID().toString(), request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.PAYMENT_FAILED));
+
+        Stock stock = stockRepository.findByProductId(product.getId()).orElseThrow();
+        assertThat(stock.getRemainingQuantity()).isEqualTo(10);
+        assertThat(orderRepository.count()).isZero();
+    }
+
     @DisplayName("Redis 장애 시 동일 멱등성 키로 재요청하면 기존 주문을 반환한다")
     @Test
     void idempotencyFallbackReturnsSameOrder() {
+        when(pgClient.pay(anyInt())).thenReturn(PaymentResult.success("txn-fallback-002"));
+
         String idempotencyKey = UUID.randomUUID().toString();
         BookingRequest request = new BookingRequest(product.getId(), List.of(
                 new PaymentRequest(PaymentMethod.CREDIT_CARD, 100000)
@@ -119,6 +153,8 @@ class BookingRedisFallbackTest {
     @DisplayName("Redis 장애 시 재고 수량만큼만 예약이 성공한다")
     @Test
     void fallbackPreventsOverselling() {
+        when(pgClient.pay(anyInt())).thenReturn(PaymentResult.success("txn-fallback-003"));
+
         stockRepository.deleteAll();
         stockRepository.saveAndFlush(Stock.create(product, 2));
 


### PR DESCRIPTION
## Summary
- Redis 장애 시 DB fallback으로 재고 차감 후 결제가 실패하면 DB 재고가 복구되지 않던 문제 수정
- `StockService.increaseWithPessimisticLock()` 보상 메서드 추가
- `BookingService`에 `stockDecreased` 플래그로 재고 차감 여부를 정확히 추적
- DECISIONS.md 및 시퀀스 다이어그램 동기화

## Test plan
- [x] `BookingRedisFallbackTest.dbStockRestoredWhenPaymentFailsInFallback` 추가 및 통과
- [x] 기존 보상 트랜잭션 테스트 전체 통과

close #260