### PR TITLE
refactor: Rate Limit 설정값 외부화 (#263)

### DIFF
--- a/src/main/java/com/reservation/global/ratelimit/RateLimitService.java
+++ b/src/main/java/com/reservation/global/ratelimit/RateLimitService.java
@@ -1,7 +1,7 @@
 package com.reservation.global.ratelimit;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -13,23 +13,32 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class RateLimitService {
 
     private static final String KEY_PREFIX = "ratelimit:user:";
-    private static final int MAX_REQUESTS = 5;
-    private static final int WINDOW_SECONDS = 1;
 
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<Long> rateLimitScript;
+    private final int maxRequests;
+    private final int windowSeconds;
     private final ConcurrentHashMap<Long, AtomicInteger> localLimitMap = new ConcurrentHashMap<>();
     private volatile long localWindowStart = System.currentTimeMillis();
+
+    public RateLimitService(StringRedisTemplate redisTemplate,
+                            RedisScript<Long> rateLimitScript,
+                            @Value("${rate-limit.max-requests:5}") int maxRequests,
+                            @Value("${rate-limit.window-seconds:1}") int windowSeconds) {
+        this.redisTemplate = redisTemplate;
+        this.rateLimitScript = rateLimitScript;
+        this.maxRequests = maxRequests;
+        this.windowSeconds = windowSeconds;
+    }
 
     public boolean isAllowed(Long userId) {
         try {
             String key = KEY_PREFIX + userId;
-            Long count = redisTemplate.execute(rateLimitScript, List.of(key), String.valueOf(WINDOW_SECONDS));
-            return count != null && count <= MAX_REQUESTS;
+            Long count = redisTemplate.execute(rateLimitScript, List.of(key), String.valueOf(windowSeconds));
+            return count != null && count <= maxRequests;
         } catch (RedisConnectionFailureException e) {
             log.warn("Redis 장애로 로컬 Rate Limiting 적용: {}", e.getMessage());
             return isAllowedLocal(userId);
@@ -38,11 +47,11 @@ public class RateLimitService {
 
     private boolean isAllowedLocal(Long userId) {
         long now = System.currentTimeMillis();
-        if (now - localWindowStart > WINDOW_SECONDS * 1000L) {
+        if (now - localWindowStart > windowSeconds * 1000L) {
             localLimitMap.clear();
             localWindowStart = now;
         }
         AtomicInteger counter = localLimitMap.computeIfAbsent(userId, k -> new AtomicInteger(0));
-        return counter.incrementAndGet() <= MAX_REQUESTS;
+        return counter.incrementAndGet() <= maxRequests;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,10 @@ resilience4j:
         permitted-number-of-calls-in-half-open-state: 2
         minimum-number-of-calls: 3
 
+rate-limit:
+  max-requests: 5
+  window-seconds: 1
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## Summary
- `RateLimitService`의 `MAX_REQUESTS`, `WINDOW_SECONDS` 상수를 `application.yml`로 외부화
- `@Value`를 통한 생성자 주입으로 코드 수정 없이 설정 변경 가능
- 기본값 유지 (5 requests / 1 second)

close #263