### PR TITLE
refactor: Order/Payment 상태 전이 검증 추가 (#264)

### DIFF
--- a/src/main/java/com/reservation/domain/order/entity/Order.java
+++ b/src/main/java/com/reservation/domain/order/entity/Order.java
@@ -51,14 +51,24 @@ public class Order extends BaseEntity {
     }
 
     public void complete() {
+        validateStatus(OrderStatus.PENDING);
         this.status = OrderStatus.COMPLETED;
     }
 
     public void fail() {
+        validateStatus(OrderStatus.PENDING);
         this.status = OrderStatus.FAILED;
     }
 
     public void cancel() {
+        validateStatus(OrderStatus.COMPLETED);
         this.status = OrderStatus.CANCELLED;
+    }
+
+    private void validateStatus(OrderStatus expected) {
+        if (this.status != expected) {
+            throw new IllegalStateException(
+                    String.format("주문 상태를 변경할 수 없습니다. 현재: %s, 필요: %s", this.status, expected));
+        }
     }
 }

--- a/src/main/java/com/reservation/domain/payment/entity/Payment.java
+++ b/src/main/java/com/reservation/domain/payment/entity/Payment.java
@@ -44,19 +44,30 @@ public class Payment extends BaseEntity {
     }
 
     public void approve(String transactionId) {
+        validateStatus(PaymentStatus.PENDING);
         this.status = PaymentStatus.APPROVED;
         this.transactionId = transactionId;
     }
 
     public void fail() {
+        validateStatus(PaymentStatus.PENDING);
         this.status = PaymentStatus.FAILED;
     }
 
     public void cancel() {
+        validateStatus(PaymentStatus.APPROVED);
         this.status = PaymentStatus.CANCELLED;
     }
 
     public void cancelFailed() {
+        validateStatus(PaymentStatus.APPROVED);
         this.status = PaymentStatus.CANCEL_FAILED;
+    }
+
+    private void validateStatus(PaymentStatus expected) {
+        if (this.status != expected) {
+            throw new IllegalStateException(
+                    String.format("결제 상태를 변경할 수 없습니다. 현재: %s, 필요: %s", this.status, expected));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `Order` 엔티티에 상태 전이 검증 추가 (PENDING → COMPLETED/FAILED, COMPLETED → CANCELLED)
- `Payment` 엔티티에 상태 전이 검증 추가 (PENDING → APPROVED/FAILED, APPROVED → CANCELLED/CANCEL_FAILED)
- 잘못된 상태 전이 시 `IllegalStateException` 발생

## Test plan
- [x] 전체 테스트 통과 확인 (BUILD SUCCESSFUL)

close #264